### PR TITLE
Add brand/campaign context system and fix structural issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,31 +107,80 @@ bash scripts/check-deps.sh
 
 ```
 scrollclaw/
-├── SKILL.md              Core doctrine + 14-step workflow
-├── README.md             You are here
-├── references/           15 reference docs (loaded on demand)
-│   ├── persona-research.md
-│   ├── script-voice.md
-│   ├── format-library.md
-│   ├── hook-emotions.md
-│   ├── green-zone.md
-│   ├── first-frame-prompting.md
-│   ├── first-frame-psychology.md
-│   ├── color-reference-system.md
-│   ├── motion-prompting.md
-│   ├── orchestrator.md
-│   ├── audio-orchestration.md
-│   ├── voice-system.md
-│   ├── post-production.md
-│   ├── virality-scoring.md
-│   └── sora-api.md
-├── scripts/              10 automation scripts
-├── evals/                Trigger + execution benchmarks
-└── assets/               Campaign brief template
+├── SKILL.md                    Router — orchestrates the full suite
+├── README.md                   You are here
+├── _system/                    Shared doctrine + context protocol
+│   ├── SKILL.md                Core doctrine, format selection, pipeline routing
+│   └── references/
+│       ├── brand-campaign-context.md   Brand memory + campaign workspace protocol
+│       ├── color-reference-system.md
+│       ├── creator-system.md
+│       ├── format-library.md
+│       └── hook-emotions.md
+├── persona/                    Step 1: Persona research + scripting
+│   ├── SKILL.md
+│   └── references/
+│       ├── persona-research.md
+│       └── script-voice.md
+├── first-frame/                Step 2: Canonical frame generation
+│   ├── SKILL.md
+│   └── references/
+│       ├── first-frame-prompting.md
+│       └── first-frame-psychology.md
+├── animate/                    Step 3: A-roll (Sora 2)
+│   ├── SKILL.md
+│   └── references/
+│       ├── motion-prompting.md
+│       └── sora-api.md
+├── b-roll/                     Step 4: B-roll (Kling 3)
+│   ├── SKILL.md
+│   └── references/
+│       ├── kling-api.md
+│       └── orchestrator.md
+├── assemble/                   Step 5: Stitch + audio + post-production + captions
+│   ├── SKILL.md
+│   └── references/
+│       ├── audio-orchestration.md
+│       ├── green-zone.md
+│       ├── orchestrator.md
+│       ├── post-production.md
+│       └── voice-system.md
+├── score/                      Step 6: Virality scoring gate
+│   ├── SKILL.md
+│   └── references/
+│       └── virality-scoring.md
+├── scripts/                    10 automation scripts
+├── evals/                      Trigger + execution benchmarks
+└── assets/                     Campaign brief template
 ```
+
+## Brand & Campaign Context
+
+ScrollClaw persists work across sessions so campaign 10 takes a fraction of campaign 1.
+
+```
+workspace/
+├── brand/                      ← Read-only for ScrollClaw (GrowthClaw or manual)
+│   ├── voice-profile.md        ← Informs script tone
+│   ├── positioning.md          ← Informs persona research direction
+│   └── audience.md             ← Anchors creator archetype selection
+├── creators/                   ← Global creator profiles (reuse across campaigns)
+└── campaigns/<slug>/
+    ├── brief.md                ← Campaign brief
+    ├── persona-research.md     ← Extracted customer language
+    ├── creators/               ← Campaign-specific creator overrides
+    ├── scripts/                ← Approved scripts
+    ├── frames/                 ← First frames + context frames
+    ├── clips/                  ← A-roll, B-roll, assembled finals
+    ├── scores/                 ← Virality score cards
+    ├── output-log.md           ← All prompt params (append-only)
+    └── learnings.md            ← What worked, what didn't (append-only)
+```
+
+Full context protocol: [`_system/references/brand-campaign-context.md`](_system/references/brand-campaign-context.md)
 
 ---
 
 Built by [Matt Berman](https://x.com/TheMattBerman) · [Emerald Digital](https://emeralddigital.dev) · [Big Players Newsletter](https://bigplayers.beehiiv.com)
 
-Full documentation: [SKILL.md](SKILL.md)
+Full documentation: [_system/SKILL.md](_system/SKILL.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: scrollclaw
+description: "AI UGC video production suite. Six sub-skills that take a brand from persona research through virality-scored video. Produces talking head, podcast clip, hook face + demo, wall of text, visual transformation, and hybrid transformation formats."
+metadata:
+  openclaw:
+    emoji: "🎬"
+    user-invocable: true
+    triggers:
+      - "scrollclaw"
+      - "ugc video"
+      - "ai ugc"
+      - "make ugc"
+      - "ugc campaign"
+      - "ugc pipeline"
+      - "talking head video"
+      - "product review video"
+      - "start ugc"
+---
+
+# ScrollClaw
+
+AI-generated UGC videos that look like a real person pulled out their phone and started talking. Brands pay $500–$5,000 per UGC video from human creators. This pipeline produces them for $5–$50 in API costs.
+
+## The Pipeline
+
+```
+Brand + Audience
+      ↓
+/persona    → Persona research, creator profiles, approved script
+/first-frame → Canonical face image (Nano Banana 2)
+/animate    → A-roll talking head clips (Sora 2 i2v)
+/b-roll     → Environment + product shots (Kling 3)
+/assemble   → Stitch + unified voice + post-production + captions
+/score      → Virality gate (70+ to publish)
+      ↓
+Scroll-stopping UGC video
+```
+
+**Core doctrine:** Read `_system/SKILL.md` for format selection, anti-patterns, taste calibration, and pipeline routing rules.
+
+**Brand & campaign context:** Read `_system/references/brand-campaign-context.md` for workspace structure, context matrix, and persistence protocol.
+
+---
+
+## Routing
+
+When the user invokes ScrollClaw or asks about UGC video, route to the right sub-skill based on where they are in the pipeline:
+
+| User says / wants | Route to |
+|-------------------|----------|
+| "Make me a UGC video" / "Start a campaign" / "I need ugc" | `/persona` — start at the beginning |
+| "Research this brand" / "Create a creator profile" / "Write a script" | `/persona` |
+| "Generate the first frame" / "Make a face image" / "Nano Banana" | `/first-frame` |
+| "Animate this" / "Make a talking head clip" / "Sora" / "A-roll" | `/animate` |
+| "Generate B-roll" / "Product shot" / "Kling" | `/b-roll` |
+| "Stitch the clips" / "Add captions" / "Post-production" / "Assemble" | `/assemble` |
+| "Score this video" / "Is this ready to publish?" | `/score` |
+| "Run the full pipeline" | Start at `/persona`, proceed sequentially |
+
+If the user isn't sure where they are, ask: **"Where are you in the pipeline?"** and show them the 6 steps above.
+
+---
+
+## Quick Start
+
+**First campaign:**
+1. Initialize workspace:
+   ```bash
+   CAMPAIGN="my-campaign"
+   mkdir -p workspace/campaigns/$CAMPAIGN/{creators,scripts,frames,clips,scores}
+   cp assets/campaign-brief-template.md workspace/campaigns/$CAMPAIGN/brief.md
+   touch workspace/campaigns/$CAMPAIGN/output-log.md
+   touch workspace/campaigns/$CAMPAIGN/learnings.md
+   ```
+2. Fill in `workspace/campaigns/$CAMPAIGN/brief.md`
+3. Run `/persona` → `/first-frame` → `/animate` → `/b-roll` → `/assemble` → `/score`
+
+**Check setup first:**
+```bash
+bash scripts/check-deps.sh
+```
+
+---
+
+## What ScrollClaw Needs
+
+| Key | Required | Used by |
+|-----|----------|---------|
+| `FAL_KEY` | Yes | Sora 2 (A-roll) + Kling 3 (B-roll) |
+| `REPLICATE_API_TOKEN` | Yes | Nano Banana (first frames) |
+| `OPENROUTER_API_KEY` | Recommended | Gemini (virality scoring) |
+| `ELEVENLABS_API_KEY` | Optional | Multi-clip voice consistency (S2S) |
+
+---
+
+## Six Formats
+
+| Format | Duration | Best for |
+|--------|----------|---------|
+| Talking Head | 15-25s | Product review, honest take |
+| Hook Face + Demo | 15s max | App/tool demos |
+| Podcast Clip | 8-20s | Authority, credibility |
+| Wall of Text | 4-8s | Hot take, faceless |
+| Visual Transformation | 10-25s | Before/after concept |
+| Hybrid Transformation | 20-30s | Complex mechanism explanation |
+
+---
+
+## Key Findings (from testing)
+
+- Sora's native voice > ElevenLabs TTS for talking head. TTS sounds fake.
+- B-roll must be environment-matched. Extract a frame from A-roll → feed to Kling.
+- Captions go LAST — after post-production. Grain degrades caption pills.
+- AI cannot generate realistic app screens. Use real screenshots.
+- ~1 in 3 Sora generations have hand artifacts. Reroll, don't fix the prompt.
+- Multi-frame formats: chain from frame 1. Parallel generation causes face drift.
+
+---
+
+For full doctrine, format blueprints, anti-patterns, and taste calibration: [`_system/SKILL.md`](_system/SKILL.md)

--- a/_system/SKILL.md
+++ b/_system/SKILL.md
@@ -91,5 +91,55 @@ Read `references/format-library.md` for shot-by-shot blueprints. Read `reference
 
 **Env:** FAL_KEY (primary), REPLICATE_API_TOKEN (Nano Banana + fallback), ELEVENLABS_API_KEY (multi-clip voice), OPENROUTER_API_KEY (Gemini virality scoring).
 
+## Brand & Campaign Context
+
+ScrollClaw persists work across sessions using a structured workspace. Campaign 10 takes a fraction of campaign 1 because creator profiles, brand context, and learnings accumulate.
+
+**Full protocol:** Read `references/brand-campaign-context.md`.
+
+### Workspace structure
+
+```
+workspace/
+├── brand/                    ← Read-only for ScrollClaw (written by GrowthClaw etc.)
+│   ├── voice-profile.md      ← Brand voice → informs script tone
+│   ├── positioning.md        ← Differentiation → informs persona research
+│   └── audience.md           ← ICP → informs creator archetype selection
+├── creators/                 ← Global creator profiles (reusable across campaigns)
+└── campaigns/<slug>/
+    ├── brief.md              ← Campaign brief (from assets/campaign-brief-template.md)
+    ├── persona-research.md   ← Written by /persona
+    ├── creators/             ← Campaign-specific creator overrides
+    ├── scripts/              ← Approved scripts
+    ├── frames/               ← First frames + context frames
+    ├── clips/                ← A-roll, B-roll, assembled finals
+    ├── scores/               ← Virality score cards
+    ├── output-log.md         ← Prompt log, generation params (append-only)
+    └── learnings.md          ← What worked, what didn't (append-only)
+```
+
+### Context matrix
+
+| Skill | Reads | Writes |
+|-------|-------|--------|
+| `/persona` | `brand/{voice-profile,positioning,audience}.md`, campaign brief | `persona-research.md`, `creators/`, `scripts/` |
+| `/first-frame` | `creators/`, `scripts/`, campaign brief | `frames/`, `output-log.md` |
+| `/animate` | `frames/`, `scripts/`, `creators/` | `clips/a-roll-*.mp4`, `output-log.md` |
+| `/b-roll` | `frames/`, `clips/a-roll-*`, `scripts/` | `clips/b-roll-*.mp4`, `output-log.md` |
+| `/assemble` | `clips/*`, `scripts/`, `creators/` | `clips/final-*.mp4`, `output-log.md` |
+| `/score` | `clips/final-*`, campaign brief, `persona-research.md` | `scores/`, `learnings.md` |
+
+### Rules for reading brand memory
+
+- Check if each brand file exists before reading. Never error on missing files.
+- Show what was loaded: `✓ Loaded brand voice: conversational-direct` / `✗ No audience file — proceeding standalone`
+- ScrollClaw reads `workspace/brand/` but **never writes** there
+
+### Rules for writing campaign files
+
+- `output-log.md` and `learnings.md` are **append-only** — never overwrite
+- Creator profiles: global ones go in `workspace/creators/`, campaign overrides in `campaigns/<slug>/creators/`
+- Skills own their outputs. `/persona` owns `persona-research.md`. `/score` owns `scores/` and `learnings.md`.
+
 ## Setup
 Run `scripts/check-deps.sh` to verify all API keys and dependencies.

--- a/_system/references/brand-campaign-context.md
+++ b/_system/references/brand-campaign-context.md
@@ -1,0 +1,175 @@
+# Brand & Campaign Context Protocol
+
+How ScrollClaw reads brand memory and persists campaign work across sessions.
+
+---
+
+## Why This Exists
+
+Campaign 10 should take a fraction of campaign 1. Creator profiles get reused. Learnings compound. Brand voice carries across every script. This document defines how.
+
+---
+
+## Workspace Directory Structure
+
+```
+workspace/
+├── brand/                          ← Read-only for ScrollClaw. Written by GrowthClaw or manually.
+│   ├── voice-profile.md            ← Brand voice, tone, language style
+│   ├── positioning.md              ← What the brand stands for, how it differentiates
+│   └── audience.md                 ← ICP, customer archetypes, demographics
+│
+├── creators/                       ← Global creator profiles (reusable across campaigns)
+│   └── creator-<name>.md
+│
+└── campaigns/
+    └── <campaign-slug>/            ← One folder per campaign
+        ├── brief.md                ← From assets/campaign-brief-template.md
+        ├── persona-research.md     ← Written by /persona
+        ├── creators/               ← Campaign-specific creator overrides (optional)
+        │   └── creator-<name>.md
+        ├── scripts/                ← Approved scripts
+        │   └── <format>-script.md
+        ├── frames/                 ← First frames + context frames
+        │   ├── frame1.png
+        │   └── environment-frame.png
+        ├── clips/                  ← All video output
+        │   ├── a-roll-01.mp4
+        │   ├── b-roll-01.mp4
+        │   └── final-<version>.mp4
+        ├── scores/                 ← Virality score cards
+        │   └── score-<version>.md
+        ├── output-log.md           ← Prompt log, generation params, model versions
+        └── learnings.md            ← What worked, what didn't (append-only — never overwrite)
+```
+
+---
+
+## Brand Context Integration
+
+ScrollClaw is a good citizen in a larger skill ecosystem. It **reads** from `workspace/brand/` but **never writes** there. Writing brand files is the job of brand-focused skills (GrowthClaw, brand-voice, etc.).
+
+### What gets read and how
+
+**`workspace/brand/voice-profile.md`**
+→ Used by `/persona` to calibrate script tone and language style. If the brand voice is "conversational and direct, no corporate speak," scripts lean into informal sentence breaks, filler acknowledgments, real pauses.
+
+**`workspace/brand/positioning.md`**
+→ Used by `/persona` to frame what the product claims and how it differentiates. Shapes which pain points get emphasized in persona research.
+
+**`workspace/brand/audience.md`**
+→ Used by `/persona` to select creator archetypes. If the audience is "35-45 suburban moms," a 22-year-old creator profile is wrong. The audience file anchors creator selection.
+
+### Graceful handling
+
+Every skill that reads brand files must handle their absence gracefully. Do not error. Do not stall. Proceed standalone:
+
+```
+✓ Loaded brand voice: conversational-direct (workspace/brand/voice-profile.md)
+✓ Loaded positioning (workspace/brand/positioning.md)
+✗ No audience file found — proceeding standalone. Creator archetype will be inferred from campaign brief.
+```
+
+Show the user exactly what was loaded and what wasn't. Never silently skip.
+
+---
+
+## Context Matrix
+
+Which sub-skills read and write which files.
+
+| Skill | Reads | Writes |
+|-------|-------|--------|
+| `/persona` | `workspace/brand/voice-profile.md`<br>`workspace/brand/positioning.md`<br>`workspace/brand/audience.md`<br>`campaigns/<slug>/brief.md` | `campaigns/<slug>/persona-research.md`<br>`campaigns/<slug>/creators/creator-<name>.md`<br>`workspace/creators/creator-<name>.md` (global profiles)<br>`campaigns/<slug>/scripts/<format>-script.md` |
+| `/first-frame` | `campaigns/<slug>/creators/creator-<name>.md`<br>`campaigns/<slug>/scripts/<format>-script.md`<br>`campaigns/<slug>/brief.md` | `campaigns/<slug>/frames/frame1.png`<br>`campaigns/<slug>/frames/environment-frame.png`<br>`campaigns/<slug>/output-log.md` |
+| `/animate` | `campaigns/<slug>/frames/frame1.png`<br>`campaigns/<slug>/scripts/<format>-script.md`<br>`campaigns/<slug>/creators/creator-<name>.md` | `campaigns/<slug>/clips/a-roll-*.mp4`<br>`campaigns/<slug>/output-log.md` |
+| `/b-roll` | `campaigns/<slug>/frames/environment-frame.png`<br>`campaigns/<slug>/clips/a-roll-*.mp4`<br>`campaigns/<slug>/scripts/<format>-script.md` | `campaigns/<slug>/clips/b-roll-*.mp4`<br>`campaigns/<slug>/output-log.md` |
+| `/assemble` | `campaigns/<slug>/clips/*.mp4`<br>`campaigns/<slug>/scripts/<format>-script.md`<br>`campaigns/<slug>/creators/creator-<name>.md` | `campaigns/<slug>/clips/final-*.mp4`<br>`campaigns/<slug>/output-log.md` |
+| `/score` | `campaigns/<slug>/clips/final-*.mp4`<br>`campaigns/<slug>/brief.md`<br>`campaigns/<slug>/persona-research.md` | `campaigns/<slug>/scores/score-<version>.md`<br>`campaigns/<slug>/learnings.md` (append-only) |
+
+**What skills do NOT read:** `/animate` does not read brand files — brand context should already be baked into the script and creator profile by `/persona`. `/b-roll` does not read persona research — it needs the A-roll frames and script, nothing else. Keep dependencies narrow.
+
+---
+
+## Creator Profile Resolution Order
+
+When a sub-skill needs a creator profile, it checks in this order:
+
+1. `campaigns/<slug>/creators/creator-<name>.md` — campaign-specific override (takes priority)
+2. `workspace/creators/creator-<name>.md` — global reusable profile
+
+If neither exists, route back to `/persona` to create one.
+
+**Creating a global vs campaign-specific profile:**
+- Use `workspace/creators/` for creators that will appear across multiple campaigns (same creator in a 3-month run)
+- Use `campaigns/<slug>/creators/` for one-off overrides (same creator archetype but different wardrobe for a specific campaign)
+
+---
+
+## Append-Only Files
+
+`learnings.md` in each campaign folder is **append-only**. Never overwrite.
+
+Format for each entry:
+
+```markdown
+## YYYY-MM-DD — [Campaign] [Format]
+
+**What worked:**
+- [specific finding]
+
+**What didn't:**
+- [specific finding]
+
+**Threshold notes:** [did this video hit 70+? what dimension dragged it down?]
+```
+
+The `/score` skill appends to this file after every scored video. Over time, these learnings feed back into scoring thresholds and format selection.
+
+---
+
+## Output Log Format
+
+`output-log.md` is a running log of all generation calls. Every skill appends to it. Never overwrite.
+
+```markdown
+## YYYY-MM-DD HH:MM — [Skill] [Step]
+
+**Model:** [model name and version]
+**Provider:** [fal / replicate / openrouter]
+**Input:** [file or param]
+**Output:** [file saved]
+**Prompt hash or key params:** [brief summary — not the full prompt, just the key decisions]
+**Generation time:** [seconds]
+**Cost estimate:** [if known]
+```
+
+This log exists so future campaigns can audit what worked. If a video scores 85+, the output log tells you exactly what parameters produced it.
+
+---
+
+## Campaign Initialization
+
+Before running any sub-skill, initialize the campaign workspace:
+
+```bash
+CAMPAIGN="ridge-q1"
+mkdir -p workspace/campaigns/$CAMPAIGN/{creators,scripts,frames,clips,scores}
+cp assets/campaign-brief-template.md workspace/campaigns/$CAMPAIGN/brief.md
+touch workspace/campaigns/$CAMPAIGN/output-log.md
+touch workspace/campaigns/$CAMPAIGN/learnings.md
+```
+
+Then fill in `brief.md` before running `/persona`.
+
+---
+
+## Cross-Campaign Learning
+
+The `/score` skill appends learnings to `campaigns/<slug>/learnings.md`. For campaigns using the same creator or brand, these learnings inform:
+
+- Which formats scored highest for this brand/audience combination
+- Which hook types stopped the scroll
+- Which creator archetypes outperformed
+
+Before starting a new campaign for the same brand, read the learnings files from previous campaigns. Look for patterns. Don't repeat experiments that already failed.

--- a/animate/SKILL.md
+++ b/animate/SKILL.md
@@ -81,10 +81,37 @@ Sora's content filter runs AFTER generation — can fail at 99%. If blocked:
 - Keep Subject descriptions generic — the first frame already defines appearance
 - fal.ai is primary provider; Replicate is backup
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/campaigns/<slug>/frames/frame1.png` | Canonical face — fed to Sora i2v to lock creator identity |
+| `workspace/campaigns/<slug>/scripts/<format>-script.md` | A-roll segments, dialogue, shot timing |
+| `workspace/campaigns/<slug>/creators/creator-<name>.md` | Creator energy/vibe reference for motion prompting |
+| `workspace/creators/creator-<name>.md` | Fallback if no campaign-specific profile exists |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/clips/a-roll-01.mp4` | One file per A-roll segment |
+| `workspace/campaigns/<slug>/output-log.md` | Motion prompt, model, duration, provider (append-only) |
+
+### Context loading
+
+```
+🎥 Animate context loaded:
+  ✓ First frame: workspace/campaigns/ridge-q1/frames/frame1.png
+  ✓ Script: talking-head (A-roll segments: 3)
+  ✓ Creator: Maya
+  ✓ Campaign: ridge-q1
+```
+
 ## Output
 
-- A-roll clips (MP4) in `campaigns/<slug>/clips/`
-- Each clip corresponds to an `[A-ROLL]` script segment
+- A-roll clips (MP4) in `workspace/campaigns/<slug>/clips/`
+- Each clip named `a-roll-<segment>.mp4` corresponding to an `[A-ROLL]` script segment
+- Generation params logged to `workspace/campaigns/<slug>/output-log.md`
 
 ## Next Step
 

--- a/assemble/SKILL.md
+++ b/assemble/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: scrollclaw-assemble
 description: "Stitch clips, unify voice with ElevenLabs S2S, apply post-production realism stack, and burn captions. The final assembly pipeline."
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 metadata:
   openclaw:
     emoji: "🔧"
@@ -14,13 +13,11 @@ metadata:
       - "ugc captions"
       - "ugc audio"
       - "ugc post-production"
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 ---
 
 # Assemble
 
 Three stages: stitch + audio → post-production → captions. Order matters.
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 
 ## Prerequisites
 
@@ -66,10 +63,10 @@ Use `scripts/stitch-video.sh` for resolution normalization. Read `references/voi
 ## Stage 2: Post-Production (mandatory)
 
 Raw AI output → post-production → final asset. Never skip.
+
 Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 
 Read `references/post-production.md` for the full realism stack: color grade, grain (the 4K upscale trick), skin texture, frame rate lock, audio realism, lighting consistency.
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 
 If mixing Sora + Kling clips, pay special attention to cross-engine color matching — see `references/orchestrator.md` (in `b-roll/references/`).
 
@@ -80,7 +77,6 @@ Read `references/green-zone.md` for platform safe zones.
 ## Stage 3: Captions (ALWAYS LAST)
 
 **⚠️ Captions MUST be applied AFTER post-production, not before.** Grain and color grade degrade clean caption pills.
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
 
 ```bash
 # Auto-detect video resolution and generate matching caption overlay
@@ -103,11 +99,38 @@ Resolution note: Sora outputs 720x1280, Kling outputs 1076x1924. Always normaliz
 
 Requires `/usr/bin/ffmpeg` (apt version with libfreetype) and `/usr/bin/python3` with PIL.
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/campaigns/<slug>/clips/*.mp4` | All A-roll and B-roll clips to assemble |
+| `workspace/campaigns/<slug>/scripts/<format>-script.md` | Timing, B-roll insertion points, caption text |
+| `workspace/campaigns/<slug>/creators/creator-<name>.md` | Voice reference for ElevenLabs S2S voice design |
+| `workspace/creators/creator-<name>.md` | Fallback if no campaign-specific profile exists |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/clips/final-<version>.mp4` | Assembled video with voice, post-production, captions |
+| `workspace/campaigns/<slug>/output-log.md` | Assembly params, S2S voice used, ffmpeg settings (append-only) |
+
+### Context loading
+
+```
+🔧 Assemble context loaded:
+  ✓ Campaign: ridge-q1
+  ✓ A-roll clips: 3 (workspace/campaigns/ridge-q1/clips/a-roll-*.mp4)
+  ✓ B-roll clips: 2 (workspace/campaigns/ridge-q1/clips/b-roll-*.mp4)
+  ✓ Script: talking-head (workspace/campaigns/ridge-q1/scripts/talking-head-script.md)
+  ✓ Creator voice profile: Maya
+```
+
 ## Output
 
-- Final assembled video (MP4) with unified voice, post-production, and captions
-Use `scripts/post-production.sh` for automated color grade, grain, and frame rate normalization.
-- All intermediate files preserved in `campaigns/<slug>/`
+- Final assembled video (MP4) in `workspace/campaigns/<slug>/clips/final-<version>.mp4`
+- All intermediate files preserved in `workspace/campaigns/<slug>/`
+- Assembly params logged to `workspace/campaigns/<slug>/output-log.md`
 
 ## Next Step
 

--- a/b-roll/SKILL.md
+++ b/b-roll/SKILL.md
@@ -67,11 +67,37 @@ Read `references/kling-api.md` for Kling 3 endpoint details, field names, and qu
 - **AI cannot generate realistic app screens or UI text.** For product/app demos: use real screenshots or screen recordings.
 - The orchestrator doc (`references/orchestrator.md`) has the full A/B-roll split methodology
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/campaigns/<slug>/frames/environment-frame.png` | Environment-matched start frame for Kling i2v |
+| `workspace/campaigns/<slug>/clips/a-roll-*.mp4` | Source clips to extract environment frames from |
+| `workspace/campaigns/<slug>/scripts/<format>-script.md` | B-roll segments and visual cues |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/clips/b-roll-01.mp4` | One file per B-roll segment |
+| `workspace/campaigns/<slug>/output-log.md` | Kling prompt, duration, provider (append-only) |
+
+### Context loading
+
+```
+🎞️ B-Roll context loaded:
+  ✓ Environment frame: workspace/campaigns/ridge-q1/frames/environment-frame.png
+  ✓ A-roll clips: 3 found (workspace/campaigns/ridge-q1/clips/)
+  ✓ Script: talking-head (B-roll segments: 2)
+  ✓ Campaign: ridge-q1
+```
+
 ## Output
 
-- B-roll clips (MP4) in `campaigns/<slug>/clips/`
-- Each clip corresponds to a `[B-ROLL]` script segment
+- B-roll clips (MP4) in `workspace/campaigns/<slug>/clips/`
+- Each clip named `b-roll-<segment>.mp4` corresponding to a `[B-ROLL]` script segment
 - Clips are visual-only — no dialogue
+- Generation params logged to `workspace/campaigns/<slug>/output-log.md`
 
 ## Next Step
 

--- a/first-frame/SKILL.md
+++ b/first-frame/SKILL.md
@@ -71,11 +71,37 @@ Iterate on frame 1 more than anything else. Expect 2-4 attempts before it passes
 
 Once frame 1 is locked, the rest chain from it.
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/campaigns/<slug>/creators/creator-<name>.md` | Creator identity — face, hair, build, wardrobe, energy |
+| `workspace/creators/creator-<name>.md` | Global creator profile (fallback if no campaign override exists) |
+| `workspace/campaigns/<slug>/scripts/<format>-script.md` | Which scene/setting the first frame needs to establish |
+| `workspace/campaigns/<slug>/brief.md` | Brand context, color cues, environment direction |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/frames/frame1.png` | Canonical face — referenced by all subsequent frames and animation |
+| `workspace/campaigns/<slug>/frames/environment-frame.png` | Context-specific frames for multi-setting formats |
+| `workspace/campaigns/<slug>/output-log.md` | Prompt params, model version, generation time (append-only) |
+
+### Context loading
+
+```
+🖼️ First Frame context loaded:
+  ✓ Creator: Maya (workspace/campaigns/ridge-q1/creators/creator-maya.md)
+  ✓ Script: talking-head (workspace/campaigns/ridge-q1/scripts/talking-head-script.md)
+  ✓ Campaign: ridge-q1
+```
+
 ## Output
 
-- Canonical first frame image (PNG) in `campaigns/<slug>/frames/`
-- Context-specific frames for multi-setting formats
-- Prompt file and output log saved
+- Canonical first frame image (PNG) in `workspace/campaigns/<slug>/frames/`
+- Context-specific frames for multi-setting formats in `workspace/campaigns/<slug>/frames/`
+- Prompt params logged to `workspace/campaigns/<slug>/output-log.md`
 
 ## Next Step
 

--- a/persona/SKILL.md
+++ b/persona/SKILL.md
@@ -74,11 +74,41 @@ Read `references/script-voice.md`. Use exact phrases from persona research. Test
 
 Mark the script with `[A-ROLL]` and `[B-ROLL]` tags. A-roll = Sora (talking head + dialogue). B-roll = Kling (everything else). Voice runs continuously over B-roll.
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/brand/voice-profile.md` | Script tone calibration — if brand voice is "conversational-direct," lean into informal breaks and real pauses |
+| `workspace/brand/positioning.md` | Which pain points to emphasize; how the product differentiates |
+| `workspace/brand/audience.md` | Creator archetype selection — anchors age, lifestyle, aesthetic |
+| `workspace/campaigns/<slug>/brief.md` | Campaign-specific product, goal, and format direction |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/persona-research.md` | Extracted phrases, pain points, exact customer language |
+| `workspace/campaigns/<slug>/creators/creator-<name>.md` | Campaign-specific creator profile |
+| `workspace/creators/creator-<name>.md` | Global reusable profile (when creator will appear across campaigns) |
+| `workspace/campaigns/<slug>/scripts/<format>-script.md` | Approved script with A/B-roll tags |
+
+### Context loading (show this to the user at session start)
+
+```
+📋 Context loaded for campaign: <slug>
+  ✓ Brand voice: <tone from voice-profile.md> (workspace/brand/voice-profile.md)
+  ✓ Positioning: <one-line summary> (workspace/brand/positioning.md)
+  ✗ No audience file found — creator archetype will be inferred from campaign brief
+  ✓ Campaign brief: workspace/campaigns/<slug>/brief.md
+```
+
+Handle missing files gracefully. Never error. Proceed standalone with a note.
+
 ## Output
 
-- Persona research doc with extracted phrases
-- Creator profile(s) in `creators/`
-- Approved script with segment mapping and A/B-roll tags
+- Persona research doc with extracted phrases — `workspace/campaigns/<slug>/persona-research.md`
+- Creator profile(s) in `workspace/campaigns/<slug>/creators/` (or `workspace/creators/` for global)
+- Approved script with segment mapping and A/B-roll tags — `workspace/campaigns/<slug>/scripts/<format>-script.md`
 - Format selection locked
 
 ## Next Step

--- a/score/SKILL.md
+++ b/score/SKILL.md
@@ -50,10 +50,57 @@ Score every video before publishing. Read `references/virality-scoring.md` for t
    - Text readability weak → `/assemble` (fix captions)
    - Audio/voice issues → `/assemble` (re-run S2S)
 
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| `workspace/campaigns/<slug>/clips/final-*.mp4` | Video(s) to score |
+| `workspace/campaigns/<slug>/brief.md` | Original campaign goals — score against intent, not just virality |
+| `workspace/campaigns/<slug>/persona-research.md` | Whether the script language matches real customer language |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/campaigns/<slug>/scores/score-<version>.md` | Score card with per-dimension breakdown and go/no-go |
+| `workspace/campaigns/<slug>/learnings.md` | Append-only — what worked, what didn't, threshold notes |
+
+### Context loading
+
+```
+📊 Score context loaded:
+  ✓ Campaign: ridge-q1
+  ✓ Final clips: 2 (workspace/campaigns/ridge-q1/clips/final-*.mp4)
+  ✓ Brief: workspace/campaigns/ridge-q1/brief.md
+  ✓ Persona research: workspace/campaigns/ridge-q1/persona-research.md
+```
+
+### Learnings append format
+
+After every score, append to `workspace/campaigns/<slug>/learnings.md`:
+
+```markdown
+## YYYY-MM-DD — <campaign-slug> <format>
+
+**Score:** <average>/100 (<go/no-go>)
+**Dimension breakdown:** Hook <n> | Emotional <n> | Pacing <n> | Captions <n> | Scroll-stop <n> | Completion <n> | Share <n>
+
+**What worked:**
+- [specific finding]
+
+**What didn't:**
+- [specific finding]
+
+**Remediation:** [if no-go: which skill to route back to and why]
+```
+
+Never overwrite this file. Only append.
+
 ## Output
 
-- Virality score card with per-dimension scores
+- Virality score card in `workspace/campaigns/<slug>/scores/score-<version>.md`
 - Go/no-go decision
+- Learnings appended to `workspace/campaigns/<slug>/learnings.md`
 - If no-go: specific remediation routing
 
 ## Batch Scoring


### PR DESCRIPTION
## What this fixes

**ScrollClaw was missing the connective tissue that makes a skill suite work as a system.** Compared to GrowthClaw's brand memory protocol and skill chaining, ScrollClaw was a collection of standalone sub-skills with no shared persistence.

### Changes (10 files, 614 insertions, 41 deletions)

**New files:**
- `SKILL.md` (root) — Orchestrator/router that maps user intent to the right sub-skill. Stays under 500 lines per the AgentSkills spec.
- `_system/references/brand-campaign-context.md` — Full brand memory and campaign persistence protocol. Workspace structure, context matrix, creator profile resolution, append-only file rules.

**Updated files:**
- `_system/SKILL.md` — Added Brand & Campaign Context section with workspace tree and context matrix
- `persona/SKILL.md` — Added Brand Memory Integration section (reads voice-profile, positioning, audience; writes persona research, creators, scripts)
- `first-frame/SKILL.md` — Added campaign workspace reads/writes
- `animate/SKILL.md` — Added campaign workspace reads/writes
- `b-roll/SKILL.md` — Added campaign workspace reads/writes
- `assemble/SKILL.md` — Added campaign workspace reads/writes, **cleaned up 5 duplicate `post-production.sh` lines**
- `score/SKILL.md` — Added campaign workspace reads/writes, learnings append protocol
- `README.md` — Fixed dead SKILL.md link, updated architecture tree to match actual folder structure, added Brand & Campaign Context section

### Key design decisions
- ScrollClaw **reads** from `workspace/brand/` but **never writes** there — good citizen in a GrowthClaw ecosystem
- Creator profiles work globally (`workspace/creators/`) and per-campaign (`campaigns/<slug>/creators/`)
- Context matrix explicitly defines what each skill reads AND what it does NOT read
- All workspace paths are absolute from workspace root, not relative