### PR TITLE
Add Kling 3 fallback chain and refactor video generation providers

### DIFF
--- a/animate/SKILL.md
+++ b/animate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrollclaw-animate
-description: "Animate first frames into A-roll talking head clips with Sora 2 via fal.ai. Motion prompting, dialogue sync, and content filter handling."
+description: "Animate first frames into A-roll talking head clips. Uses Sora 2 via fal.ai (primary) with Kling 3 auto-fallback when Sora is unavailable or sunset."
 metadata:
   openclaw:
     emoji: "🎥"
@@ -12,11 +12,15 @@ metadata:
       - "a-roll"
       - "talking head clip"
       - "sora video"
+      - "kling animate"
+      - "kling a-roll"
 ---
 
 # Animate (A-Roll)
 
-Sora 2 turns first frames into talking head clips with synced lip movement and audio. Image-to-video is the default — text-to-video is the fallback.
+Turns first frames into talking head clips with synced lip movement and audio. Image-to-video is the default — text-to-video is the fallback.
+
+**Fallback chain:** Sora 2 (fal.ai) -> Kling 3 (fal.ai) -> Kling 3 (Replicate). Use `--provider kling` to skip Sora entirely (for when Sora is sunset).
 
 ## Prerequisites
 
@@ -58,7 +62,17 @@ bash scripts/generate-clip.sh \
   --label a-roll-01 \
   --seconds 8 --aspect-ratio portrait
 
-# Replicate fallback (if fal.ai is down)
+# Kling direct (skip Sora — use when Sora is sunset)
+bash scripts/generate-clip.sh \
+  --provider kling \
+  --image workspace/campaigns/<slug>/frames/frame1.png \
+  --prompt-file workspace/campaigns/<slug>/motion-prompt.txt \
+  --output workspace/campaigns/<slug>/clips/a-roll-01.mp4 \
+  --log-file workspace/campaigns/<slug>/output-log.md \
+  --label a-roll-01 \
+  --seconds 8 --aspect-ratio portrait
+
+# Replicate Sora (legacy — may stop working when Sora is sunset)
 bash scripts/generate-clip.sh \
   --provider replicate \
   --image workspace/campaigns/<slug>/frames/frame1.png \
@@ -71,7 +85,7 @@ bash scripts/generate-clip.sh \
 
 ## API Reference
 
-Read `references/sora-api.md` for endpoint details, queue workflow, field names, and duration options. fal.ai supports 4/8/12/16/20s. Replicate is limited to 4/8/12.
+Read `references/sora-api.md` for endpoint details, queue workflow, field names, and duration options. Sora fal.ai supports 4/8/12/16/20s. Kling supports 3-15s (durations >15s are auto-clamped). Replicate Sora is limited to 4/8/12.
 
 ## Content Filter Handling
 
@@ -79,13 +93,15 @@ Sora's content filter runs AFTER generation — can fail at 99%. If blocked:
 - Soften the motion prompt (keep first frame)
 - Remove any potentially sensitive descriptions
 - Retry with adjusted prompt
+- Or use `--provider kling` — Kling has no content safety filter
 
 ## Key Findings
 
 - Include actual script in Dialogue field — Sora generates synced lip movement
 - For podcast audio: describe the RESULT, not the gear
 - Keep Subject descriptions generic — the first frame already defines appearance
-- fal.ai is primary provider; Replicate is backup
+- fal.ai is primary provider; Kling 3 is auto-fallback when Sora fails or is sunset
+- Use `--provider kling` to skip Sora entirely
 
 ## Brand Memory Integration
 

--- a/animate/references/sora-api.md
+++ b/animate/references/sora-api.md
@@ -1,11 +1,11 @@
 # Video API Reference
 
-# Video API Reference
-
 Single source of truth for all video generation endpoints. Based on real testing, not documentation speculation.
 
-**Primary provider:** fal.ai (better features, longer duration, correct field names)
-**Fallback provider:** Replicate (Nano Banana first frames, backup for Sora/Kling)
+**A-roll primary:** fal.ai Sora 2 (talking head with synced dialogue)
+**A-roll fallback:** fal.ai Kling 3 (when Sora is unavailable/sunset)
+**Final fallback:** Replicate Kling 3 (when fal.ai is down)
+**Image generation:** Replicate only (Nano Banana first frames)
 
 ---
 
@@ -129,6 +129,85 @@ The `fal-ai/sora-2/characters` endpoint exists but **blocks AI-generated faces**
 
 ---
 
+## fal.ai — Kling 3 (A-ROLL FALLBACK)
+
+Auto-fallback when Sora fails or is sunset. Use `--provider kling` to skip Sora entirely.
+
+**Key difference from B-roll usage:** A-roll requires `generate_audio: true` for dialogue lip-sync. No content safety filter (advantage over Sora).
+
+### Endpoints
+
+| Use | Endpoint |
+|-----|----------|
+| Text-to-Video Pro | `fal-ai/kling-video/v3/pro/text-to-video` |
+| Image-to-Video Pro | `fal-ai/kling-video/v3/pro/image-to-video` |
+| Text-to-Video Standard | `fal-ai/kling-video/v3/standard/text-to-video` |
+| Image-to-Video Standard | `fal-ai/kling-video/v3/standard/image-to-video` |
+
+### Queue workflow
+
+Same as Sora — submit to full endpoint path, poll using the returned `status_url`.
+
+### Image-to-Video input schema (A-roll)
+
+| Field | Type | Required | Values | Notes |
+|-------|------|----------|--------|-------|
+| prompt | string | yes | free text | Motion/dialogue description |
+| start_image_url | string | yes | URL | **Field is `start_image_url`** not `image_url`. First frame. |
+| duration | integer | no | 3-15 | Integer, not enum. Clips >15s are clamped. |
+| aspect_ratio | enum | no | "9:16", "16:9", "1:1" | Ignored when start_image_url provided. |
+| generate_audio | boolean | **yes for A-roll** | true | **Must be true** — A-roll needs synced dialogue audio. |
+| negative_prompt | string | no | free text | What to avoid |
+
+### Text-to-Video input schema (A-roll)
+
+| Field | Type | Required | Values | Notes |
+|-------|------|----------|--------|-------|
+| prompt | string | yes | free text | Scene + dialogue description |
+| duration | integer | no | 3-15 | Integer |
+| aspect_ratio | enum | no | "9:16", "16:9", "1:1" | Required for t2v |
+| generate_audio | boolean | **yes for A-roll** | true | **Must be true** |
+| negative_prompt | string | no | free text | |
+
+### Payload example (A-roll i2v)
+
+```json
+{
+  "prompt": "Camera: handheld iPhone-style front camera...\nDialogue: \"...and that is the part nobody talks about...\"\n...",
+  "start_image_url": "https://v3b.fal.media/files/.../coach-dan-frame.png",
+  "duration": 12,
+  "aspect_ratio": "9:16",
+  "generate_audio": true
+}
+```
+
+### Duration clamping
+
+Sora supports up to 20s. Kling max is 15s. If a script requests >15s, `generate-clip.sh` automatically clamps to 15s with a warning. For longer clips, use `extend-clip.sh` to chain multiple Kling generations.
+
+### Timing (from real testing)
+
+| Type | Duration | Generation time |
+|------|----------|----------------|
+| i2v Pro 5s | 5s | ~100s |
+| t2v Pro 5s | 5s | ~80s |
+
+Kling is **significantly faster** than Sora (~2 min vs ~5-10 min).
+
+### Response shape
+
+```json
+{
+  "video": {
+    "url": "https://...",
+    "content_type": "video/mp4",
+    "duration": 12.0
+  }
+}
+```
+
+---
+
 
 ## Replicate (FALLBACK)
 
@@ -204,14 +283,16 @@ Applies to Sora (both fal.ai and Replicate). Does NOT apply to Kling.
 
 The same concept has different field names per provider. This is the #1 source of silent failures.
 
+**Note:** fal.ai Kling is used for both B-roll and A-roll (as Sora fallback). For A-roll, always set `generate_audio: true`.
+
 | Concept | fal.ai Sora | fal.ai Kling | Replicate Sora | Replicate Kling Omni |
 |---------|------------|-------------|---------------|---------------------|
 | First frame image | `image_url` | `start_image_url` | `input_reference` | `start_image` |
 | Duration | `duration` (int enum: 4,8,12,16,20) | `duration` (int: 3-15) | `seconds` (int enum: 4,8,12) | `duration` (int: 3-15) |
-| Aspect ratio | `"9:16"` / `"16:9"` | `"9:16"` / `"16:9"` | `"portrait"` / `"landscape"` | `"9:16"` / `"16:9"` |
+| Aspect ratio | `"9:16"` / `"16:9"` | `"9:16"` / `"16:9"` / `"1:1"` | `"portrait"` / `"landscape"` | `"9:16"` / `"16:9"` |
 | Quality tier | `resolution`: "720p"/"1080p" | N/A (use pro endpoint) | `resolution`: "standard"/"high" | `mode`: "standard"/"pro" |
 | Character refs | `character_ids` (blocked) | N/A | N/A | `reference_images` + `<<<image_N>>>` |
-| Audio | always on (Sora) | `generate_audio` (default false) | always on (Sora) | `generate_audio` (default false) |
+| Audio | always on (Sora) | `generate_audio` (**true for A-roll**, false for B-roll) | always on (Sora) | `generate_audio` (**true for A-roll**) |
 
 ---
 

--- a/scripts/batch-campaign.sh
+++ b/scripts/batch-campaign.sh
@@ -23,6 +23,7 @@ FORMATS=""
 SECONDS_DUR="8"
 DUAL_OUTPUT=""
 PRO=""
+PROVIDER=""
 CHARACTER_IDS_FILE=""
 DRY_RUN="false"
 
@@ -35,7 +36,8 @@ usage() {
     echo "  --formats LIST        Comma-separated format names (required)"
     echo "  --seconds N           Duration per clip (default: 8)"
     echo "  --dual-output         Generate both 16:9 and 9:16"
-    echo "  --pro                 Use Sora 2 Pro"
+    echo "  --pro                 Use Pro model tier"
+    echo "  --provider NAME       fal, kling, or replicate (default: fal)"
     echo "  --character-ids FILE  JSON file mapping creator names to character_ids"
     echo "  --dry-run             Show what would be generated without running"
     exit 1
@@ -49,6 +51,7 @@ while [[ $# -gt 0 ]]; do
         --seconds) SECONDS_DUR="$2"; shift 2 ;;
         --dual-output) DUAL_OUTPUT="--dual-output"; shift ;;
         --pro) PRO="--pro"; shift ;;
+        --provider) PROVIDER="$2"; shift 2 ;;
         --character-ids) CHARACTER_IDS_FILE="$2"; shift 2 ;;
         --dry-run) DRY_RUN="true"; shift ;;
         *) echo "Unknown option: $1"; usage ;;
@@ -58,7 +61,6 @@ done
 [[ -z "$WORKSPACE" ]] && { echo "Error: --workspace required"; usage; }
 [[ -z "$CREATORS_DIR" ]] && { echo "Error: --creators required"; usage; }
 [[ -z "$FORMATS" ]] && { echo "Error: --formats required"; usage; }
-[[ -z "${REPLICATE_API_TOKEN:-}" ]] && { echo "Error: REPLICATE_API_TOKEN not set"; exit 2; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -125,6 +127,7 @@ for CREATOR_FILE in "${CREATOR_FILES[@]}"; do
 
         EXTRA_ARGS=()
         [[ -n "$PRO" ]] && EXTRA_ARGS+=("$PRO")
+        [[ -n "$PROVIDER" ]] && EXTRA_ARGS+=("--provider" "$PROVIDER")
 
         if bash "$SCRIPT_DIR/generate-clip.sh" \
             --prompt-file "$PROMPT_FILE" \

--- a/scripts/extend-clip.sh
+++ b/scripts/extend-clip.sh
@@ -19,6 +19,7 @@ SECONDS_DUR="10"
 ASPECT_RATIO="portrait"
 CHARACTER_ID=""
 PRO="false"
+PROVIDER=""
 LOG_FILE=""
 LABEL="extension"
 TIMEOUT=600
@@ -34,7 +35,8 @@ usage() {
     echo "  --seconds N           Extension duration (default: 10)"
     echo "  --aspect-ratio RATIO  9:16, 16:9, or 1:1 (default: 9:16)"
     echo "  --character-id ID     Sora character ID"
-    echo "  --pro                 Use Sora 2 Pro"
+    echo "  --pro                 Use Pro model tier"
+    echo "  --provider NAME       fal, kling, or replicate (passed to generate-clip.sh)"
     echo "  --log-file FILE       Append to output log"
     echo "  --label TEXT          Label for log entry"
     exit 1
@@ -49,6 +51,7 @@ while [[ $# -gt 0 ]]; do
         --aspect-ratio) ASPECT_RATIO="$2"; shift 2 ;;
         --character-id) CHARACTER_ID="$2"; shift 2 ;;
         --pro) PRO="true"; shift ;;
+        --provider) PROVIDER="$2"; shift 2 ;;
         --log-file) LOG_FILE="$2"; shift 2 ;;
         --label) LABEL="$2"; shift 2 ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
@@ -59,7 +62,6 @@ done
 [[ -z "$INPUT" ]] && { echo "Error: --input required"; usage; }
 [[ -z "$PROMPT_FILE" ]] && { echo "Error: --prompt-file required"; usage; }
 [[ -z "$OUTPUT" ]] && { echo "Error: --output required"; usage; }
-[[ -z "${REPLICATE_API_TOKEN:-}" ]] && { echo "Error: REPLICATE_API_TOKEN not set"; exit 2; }
 command -v ffmpeg &>/dev/null || { echo "Error: ffmpeg required for frame extraction"; exit 2; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -99,6 +101,7 @@ echo "Generating ${SECONDS_DUR}s extension..."
 EXTRA_ARGS="--image $FRAME_URL"
 [[ -n "$CHARACTER_ID" ]] && EXTRA_ARGS="$EXTRA_ARGS --character-id $CHARACTER_ID"
 [[ "$PRO" == "true" ]] && EXTRA_ARGS="$EXTRA_ARGS --pro"
+[[ -n "$PROVIDER" ]] && EXTRA_ARGS="$EXTRA_ARGS --provider $PROVIDER"
 [[ -n "$LOG_FILE" ]] && EXTRA_ARGS="$EXTRA_ARGS --log-file $LOG_FILE"
 
 bash "$SCRIPT_DIR/generate-clip.sh" \

--- a/scripts/generate-clip.sh
+++ b/scripts/generate-clip.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Generate a video clip via Sora 2 on fal.ai (default) or Replicate.
+# Generate a video clip via Sora 2 or Kling 3 on fal.ai, with Replicate fallback.
 # Supports both text-to-video and image-to-video (first frame).
 #
+# Fallback chain (default --provider fal):
+#   Sora 2 fal.ai -> Kling 3 fal.ai -> Kling 3 Replicate
+#
 # Usage:
-#   # Text to video (fal.ai, default)
+#   # Text to video (fal.ai, default — tries Sora then Kling)
 #   bash generate-clip.sh --prompt-file scene.txt --output clip.mp4 --seconds 8
 #
 #   # Image to video (fal.ai)
 #   bash generate-clip.sh --image frame1.png --prompt-file motion.txt --output clip.mp4 --seconds 8
 #
-#   # Via Replicate
+#   # Skip Sora, use Kling directly (for when Sora is sunset)
+#   bash generate-clip.sh --provider kling --prompt-file scene.txt --output clip.mp4 --seconds 8
+#
+#   # Via Replicate (Sora — legacy)
 #   bash generate-clip.sh --provider replicate --prompt-file scene.txt --output clip.mp4 --seconds 8
-#
-#   # With character consistency (Replicate only)
-#   bash generate-clip.sh --provider replicate --prompt-file scene.txt --output clip.mp4 --character-id char_123
-#
-#   # Dual output (16:9 + 9:16)
-#   bash generate-clip.sh --prompt-file scene.txt --output clip.mp4 --dual-output
 
 PROMPT_FILE=""
 IMAGE=""
@@ -41,8 +41,11 @@ usage() {
     echo "  --output FILE         Output video path (required)"
     echo "  --seconds N           Duration in seconds (default: 8)"
     echo "  --aspect-ratio RATIO  portrait or landscape (default: portrait)"
-    echo "  --pro                 Use Sora 2 Pro model"
-    echo "  --provider NAME       fal or replicate (default: fal)"
+    echo "  --pro                 Use Pro model tier"
+    echo "  --provider NAME       fal, kling, or replicate (default: fal)"
+    echo "                        fal: tries Sora then Kling then Replicate Kling"
+    echo "                        kling: skips Sora, tries Kling fal then Replicate"
+    echo "                        replicate: Sora on Replicate (legacy)"
     echo "  --log-file FILE       Append to output log"
     echo "  --label TEXT          Label for log entry"
     echo "  --timeout N           Timeout in seconds (default: 600)"
@@ -71,15 +74,35 @@ done
 PROMPT=$(cat "$PROMPT_FILE")
 
 # ---------------------------------------------------------------------------
-# fal.ai provider
+# Shared: normalize aspect ratio before dispatch
+# ---------------------------------------------------------------------------
+MAPPED_ASPECT="$ASPECT_RATIO"
+[[ "$ASPECT_RATIO" == "portrait" ]] && MAPPED_ASPECT="9:16"
+[[ "$ASPECT_RATIO" == "landscape" ]] && MAPPED_ASPECT="16:9"
+
+# ---------------------------------------------------------------------------
+# Shared logging helper
+# ---------------------------------------------------------------------------
+log_entry() {
+    local model="$1"
+    local run_id="$2"
+    local dur="$3"
+    TIMESTAMP=$(date -Iseconds)
+    mkdir -p "$(dirname "$LOG_FILE")"
+    if [[ ! -f "$LOG_FILE" ]]; then
+        echo '# Output Log' > "$LOG_FILE"
+        echo '' >> "$LOG_FILE"
+        echo '| Timestamp | Label | Model | Seconds | Provider | Output | Notes |' >> "$LOG_FILE"
+        echo '|---|---|---|---|---|---|---|' >> "$LOG_FILE"
+    fi
+    echo "| $TIMESTAMP | $LABEL | $model | $dur | $PROVIDER | $OUTPUT | id=$run_id |" >> "$LOG_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# fal.ai Sora 2 provider
 # ---------------------------------------------------------------------------
 generate_fal() {
     [[ -z "${FAL_KEY:-}" ]] && { echo "Error: FAL_KEY not set"; exit 2; }
-
-    # Map aspect_ratio names: portrait -> 9:16, landscape -> 16:9, pass through ratios
-    FAL_ASPECT="$ASPECT_RATIO"
-    [[ "$ASPECT_RATIO" == "portrait" ]] && FAL_ASPECT="9:16"
-    [[ "$ASPECT_RATIO" == "landscape" ]] && FAL_ASPECT="16:9"
 
     # fal.ai Sora duration must be one of: 4, 8, 12, 16, 20
     FAL_DURATION="$SECONDS_DUR"
@@ -95,7 +118,7 @@ generate_fal() {
             --arg prompt "$PROMPT" \
             --arg image "$IMAGE" \
             --argjson duration "$FAL_DURATION" \
-            --arg ar "$FAL_ASPECT" \
+            --arg ar "$MAPPED_ASPECT" \
             '{prompt: $prompt, image_url: $image, duration: $duration, aspect_ratio: $ar}')
         echo "Mode: image-to-video (Sora i2v via fal.ai)"
     else
@@ -107,13 +130,13 @@ generate_fal() {
         INPUT_JSON=$(jq -n \
             --arg prompt "$PROMPT" \
             --argjson duration "$FAL_DURATION" \
-            --arg ar "$FAL_ASPECT" \
+            --arg ar "$MAPPED_ASPECT" \
             '{prompt: $prompt, duration: $duration, aspect_ratio: $ar}')
         echo "Mode: text-to-video (Sora t2v via fal.ai)"
     fi
 
     echo "Endpoint: $ENDPOINT"
-    echo "Duration: ${FAL_DURATION}s | Aspect: $FAL_ASPECT"
+    echo "Duration: ${FAL_DURATION}s | Aspect: $MAPPED_ASPECT"
 
     # Submit to queue
     RESPONSE=$(curl -s -X POST "$ENDPOINT" \
@@ -126,9 +149,9 @@ generate_fal() {
     REQUEST_ID=$(echo "$RESPONSE" | jq -r '.request_id // empty')
 
     if [[ -z "$STATUS_URL" || -z "$REQUEST_ID" ]]; then
-        echo "Error submitting to fal.ai:" >&2
+        echo "Error submitting to fal.ai (Sora):" >&2
         echo "$RESPONSE" | jq . >&2
-        exit 1
+        return 1
     fi
 
     echo "Request: $REQUEST_ID"
@@ -152,14 +175,14 @@ generate_fal() {
                 ;;
             FAILED)
                 ERROR=$(echo "$POLL" | jq -r '.error // "unknown error"')
-                echo "Generation failed: $ERROR" >&2
-                exit 1
+                echo "Sora generation failed: $ERROR" >&2
+                return 1
                 ;;
             *)
                 ELAPSED=$(( $(date +%s) - START_TIME ))
                 if [[ $ELAPSED -gt $TIMEOUT ]]; then
-                    echo "Timeout after ${TIMEOUT}s" >&2
-                    exit 1
+                    echo "Sora timeout after ${TIMEOUT}s" >&2
+                    return 1
                 fi
                 echo "  Status: $STATUS (${ELAPSED}s elapsed)"
                 sleep "$POLL_INTERVAL"
@@ -171,25 +194,19 @@ generate_fal() {
     mkdir -p "$(dirname "$OUTPUT")"
     VIDEO_URL=$(echo "$RESULT" | jq -r '.video.url // empty')
     if [[ -z "$VIDEO_URL" || "$VIDEO_URL" == "null" ]]; then
-        echo "Error: No video URL in response" >&2
+        echo "Error: No video URL in Sora response" >&2
         echo "$RESULT" | jq . >&2
-        exit 1
+        return 1
     fi
 
     curl -s -o "$OUTPUT" "$VIDEO_URL"
     echo "Saved: $OUTPUT ($(du -h "$OUTPUT" | cut -f1))"
 
-    # Log if requested
+    # Log
     if [[ -n "$LOG_FILE" ]]; then
-        TIMESTAMP=$(date -Iseconds)
-        mkdir -p "$(dirname "$LOG_FILE")"
-        if [[ ! -f "$LOG_FILE" ]]; then
-            echo '# Output Log' > "$LOG_FILE"
-            echo '' >> "$LOG_FILE"
-            echo '| Timestamp | Label | Model | Seconds | Output | Notes |' >> "$LOG_FILE"
-            echo '|---|---|---|---|---|---|' >> "$LOG_FILE"
-        fi
-        echo "| $TIMESTAMP | $LABEL | fal-ai/sora-2-pro | $FAL_DURATION | $OUTPUT | request=$REQUEST_ID |" >> "$LOG_FILE"
+        local model="fal-ai/sora-2"
+        [[ "$PRO" == "true" ]] && model="fal-ai/sora-2-pro"
+        log_entry "$model" "$REQUEST_ID" "$FAL_DURATION"
     fi
 
     echo ""
@@ -197,7 +214,120 @@ generate_fal() {
 }
 
 # ---------------------------------------------------------------------------
-# Replicate provider
+# fal.ai Kling 3 provider (A-roll fallback)
+# ---------------------------------------------------------------------------
+generate_kling_fal() {
+    [[ -z "${FAL_KEY:-}" ]] && { echo "Error: FAL_KEY not set"; exit 2; }
+
+    # Kling duration: 3-15 seconds (clamp if outside range)
+    KLING_DURATION="$SECONDS_DUR"
+    if [[ "$KLING_DURATION" -gt 15 ]]; then
+        echo "Warning: Duration clamped from ${KLING_DURATION}s to 15s (Kling max)" >&2
+        KLING_DURATION=15
+    fi
+    if [[ "$KLING_DURATION" -lt 3 ]]; then
+        echo "Warning: Duration clamped from ${KLING_DURATION}s to 3s (Kling min)" >&2
+        KLING_DURATION=3
+    fi
+
+    # Choose endpoint: i2v if image provided, t2v otherwise
+    if [[ -n "$IMAGE" ]]; then
+        ENDPOINT="https://queue.fal.run/fal-ai/kling-video/v3/pro/image-to-video"
+        INPUT_JSON=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg image "$IMAGE" \
+            --argjson duration "$KLING_DURATION" \
+            --arg ar "$MAPPED_ASPECT" \
+            '{prompt: $prompt, start_image_url: $image, duration: $duration, aspect_ratio: $ar, generate_audio: true}')
+        echo "Mode: image-to-video (Kling i2v via fal.ai)"
+    else
+        ENDPOINT="https://queue.fal.run/fal-ai/kling-video/v3/pro/text-to-video"
+        INPUT_JSON=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --argjson duration "$KLING_DURATION" \
+            --arg ar "$MAPPED_ASPECT" \
+            '{prompt: $prompt, duration: $duration, aspect_ratio: $ar, generate_audio: true}')
+        echo "Mode: text-to-video (Kling t2v via fal.ai)"
+    fi
+
+    echo "Endpoint: $ENDPOINT"
+    echo "Duration: ${KLING_DURATION}s | Aspect: $MAPPED_ASPECT | Audio: true"
+
+    # Submit to queue
+    RESPONSE=$(curl -s -X POST "$ENDPOINT" \
+        -H "Authorization: Key $FAL_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$INPUT_JSON")
+
+    # Use the exact status_url returned by fal.ai
+    STATUS_URL=$(echo "$RESPONSE" | jq -r '.status_url // empty')
+    REQUEST_ID=$(echo "$RESPONSE" | jq -r '.request_id // empty')
+
+    if [[ -z "$STATUS_URL" || -z "$REQUEST_ID" ]]; then
+        echo "Error submitting to fal.ai (Kling):" >&2
+        echo "$RESPONSE" | jq . >&2
+        return 1
+    fi
+
+    echo "Request: $REQUEST_ID"
+    echo "Polling: $STATUS_URL"
+
+    START_TIME=$(date +%s)
+    while true; do
+        POLL=$(curl -s -H "Authorization: Key $FAL_KEY" "$STATUS_URL")
+        STATUS=$(echo "$POLL" | jq -r '.status')
+
+        case "$STATUS" in
+            COMPLETED)
+                echo "Generation complete!"
+                RESPONSE_URL=$(echo "$RESPONSE" | jq -r '.response_url // empty')
+                if [[ -n "$RESPONSE_URL" ]]; then
+                    RESULT=$(curl -s -H "Authorization: Key $FAL_KEY" "$RESPONSE_URL")
+                else
+                    RESULT="$POLL"
+                fi
+                break
+                ;;
+            FAILED)
+                ERROR=$(echo "$POLL" | jq -r '.error // "unknown error"')
+                echo "Kling generation failed: $ERROR" >&2
+                return 1
+                ;;
+            *)
+                ELAPSED=$(( $(date +%s) - START_TIME ))
+                if [[ $ELAPSED -gt $TIMEOUT ]]; then
+                    echo "Kling timeout after ${TIMEOUT}s" >&2
+                    return 1
+                fi
+                echo "  Status: $STATUS (${ELAPSED}s elapsed)"
+                sleep "$POLL_INTERVAL"
+                ;;
+        esac
+    done
+
+    # Download output
+    VIDEO_URL=$(echo "$RESULT" | jq -r '.video.url // empty')
+    if [[ -z "$VIDEO_URL" || "$VIDEO_URL" == "null" ]]; then
+        echo "Error: No video URL in Kling response" >&2
+        echo "$RESULT" | jq . >&2
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$OUTPUT")"
+    curl -s -o "$OUTPUT" "$VIDEO_URL"
+    echo "Saved: $OUTPUT ($(du -h "$OUTPUT" | cut -f1))"
+
+    # Log
+    if [[ -n "$LOG_FILE" ]]; then
+        log_entry "fal-ai/kling-v3-pro" "$REQUEST_ID" "$KLING_DURATION"
+    fi
+
+    echo ""
+    echo "Done. Request ID: $REQUEST_ID"
+}
+
+# ---------------------------------------------------------------------------
+# Replicate Sora provider (legacy)
 # ---------------------------------------------------------------------------
 generate_replicate() {
     [[ -z "${REPLICATE_API_TOKEN:-}" ]] && { echo "Error: REPLICATE_API_TOKEN not set"; exit 2; }
@@ -305,17 +435,128 @@ EOF
         exit 1
     fi
 
-    # Log if requested
+    # Log
     if [[ -n "$LOG_FILE" ]]; then
-        TIMESTAMP=$(date -Iseconds)
-        mkdir -p "$(dirname "$LOG_FILE")"
-        if [[ ! -f "$LOG_FILE" ]]; then
-            echo '# Output Log' > "$LOG_FILE"
-            echo '' >> "$LOG_FILE"
-            echo '| Timestamp | Label | Model | Seconds | Output | Notes |' >> "$LOG_FILE"
-            echo '|---|---|---|---|---|---|' >> "$LOG_FILE"
+        log_entry "$MODEL_PATH" "$PREDICTION_ID" "$SECONDS_DUR"
+    fi
+
+    echo ""
+    echo "Done. Prediction ID: $PREDICTION_ID"
+}
+
+# ---------------------------------------------------------------------------
+# Replicate Kling provider (final fallback)
+# ---------------------------------------------------------------------------
+generate_replicate_kling() {
+    [[ -z "${REPLICATE_API_TOKEN:-}" ]] && { echo "Error: REPLICATE_API_TOKEN not set"; exit 2; }
+
+    MODEL="kwaivgi/kling-v3-omni-video"
+
+    # Kling duration: 3-15 seconds (clamp if outside range)
+    KLING_DURATION="$SECONDS_DUR"
+    if [[ "$KLING_DURATION" -gt 15 ]]; then
+        echo "Warning: Duration clamped from ${KLING_DURATION}s to 15s (Kling max)" >&2
+        KLING_DURATION=15
+    fi
+    if [[ "$KLING_DURATION" -lt 3 ]]; then
+        echo "Warning: Duration clamped from ${KLING_DURATION}s to 3s (Kling min)" >&2
+        KLING_DURATION=3
+    fi
+
+    # Build input JSON — A-roll needs audio for dialogue sync
+    INPUT_JSON=$(jq -n \
+        --arg prompt "$PROMPT" \
+        --argjson duration "$KLING_DURATION" \
+        --arg ar "$MAPPED_ASPECT" \
+        '{prompt: $prompt, duration: $duration, aspect_ratio: $ar, generate_audio: true}')
+
+    if [[ -n "$IMAGE" ]]; then
+        if [[ "$IMAGE" == http* ]]; then
+            INPUT_JSON=$(echo "$INPUT_JSON" | jq --arg img "$IMAGE" '. + {start_image: $img}')
+        else
+            echo "Uploading first frame to Replicate..."
+            UPLOAD_RESP=$(curl -s -X POST "https://api.replicate.com/v1/files" \
+                -H "Authorization: Token $REPLICATE_API_TOKEN" \
+                -F "content=@$IMAGE" \
+                -F "content_type=image/png")
+            FILE_URL=$(echo "$UPLOAD_RESP" | jq -r '.urls.get // empty')
+            if [[ -z "$FILE_URL" ]]; then
+                echo "Error uploading file:" >&2
+                echo "$UPLOAD_RESP" | jq . >&2
+                exit 1
+            fi
+            echo "Uploaded: $FILE_URL"
+            INPUT_JSON=$(echo "$INPUT_JSON" | jq --arg img "$FILE_URL" '. + {start_image: $img}')
         fi
-        echo "| $TIMESTAMP | $LABEL | $MODEL_PATH | $SECONDS_DUR | $OUTPUT | prediction=$PREDICTION_ID |" >> "$LOG_FILE"
+        echo "Mode: image-to-video (Kling Omni via Replicate)"
+    else
+        echo "Mode: text-to-video (Kling Omni via Replicate)"
+    fi
+
+    PAYLOAD=$(jq -n --argjson input "$INPUT_JSON" '{input: $input}')
+
+    echo "Model: $MODEL"
+    echo "Duration: ${KLING_DURATION}s | Aspect: $MAPPED_ASPECT | Audio: true"
+
+    RESPONSE=$(curl -s -X POST "https://api.replicate.com/v1/models/${MODEL}/predictions" \
+        -H "Authorization: Token $REPLICATE_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$PAYLOAD")
+
+    PREDICTION_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+    GET_URL=$(echo "$RESPONSE" | jq -r '.urls.get // empty')
+
+    if [[ -z "$PREDICTION_ID" || -z "$GET_URL" ]]; then
+        echo "Error creating prediction:" >&2
+        echo "$RESPONSE" | jq . >&2
+        exit 1
+    fi
+
+    echo "Prediction: $PREDICTION_ID"
+    echo "Polling..."
+
+    START_TIME=$(date +%s)
+    while true; do
+        POLL=$(curl -s -H "Authorization: Token $REPLICATE_API_TOKEN" "$GET_URL")
+        STATUS=$(echo "$POLL" | jq -r '.status')
+
+        case "$STATUS" in
+            succeeded)
+                echo "Generation complete!"
+                break
+                ;;
+            failed|canceled)
+                ERROR=$(echo "$POLL" | jq -r '.error // "unknown error"')
+                echo "Generation $STATUS: $ERROR" >&2
+                exit 1
+                ;;
+            *)
+                ELAPSED=$(( $(date +%s) - START_TIME ))
+                if [[ $ELAPSED -gt $TIMEOUT ]]; then
+                    echo "Timeout after ${TIMEOUT}s" >&2
+                    exit 1
+                fi
+                echo "  Status: $STATUS (${ELAPSED}s elapsed)"
+                sleep "$POLL_INTERVAL"
+                ;;
+        esac
+    done
+
+    # Download output
+    mkdir -p "$(dirname "$OUTPUT")"
+    VIDEO_URL=$(echo "$POLL" | jq -r '.output // empty')
+    if [[ -n "$VIDEO_URL" && "$VIDEO_URL" != "null" ]]; then
+        curl -s -o "$OUTPUT" "$VIDEO_URL"
+        echo "Saved: $OUTPUT ($(du -h "$OUTPUT" | cut -f1))"
+    else
+        echo "Error: No output URL in response" >&2
+        echo "$POLL" | jq '.output' >&2
+        exit 1
+    fi
+
+    # Log
+    if [[ -n "$LOG_FILE" ]]; then
+        log_entry "$MODEL" "$PREDICTION_ID" "$KLING_DURATION"
     fi
 
     echo ""
@@ -327,13 +568,32 @@ EOF
 # ---------------------------------------------------------------------------
 case "$PROVIDER" in
     fal)
-        generate_fal
+        # Default: try Sora first, fall back to Kling fal, then Kling Replicate
+        if ! generate_fal; then
+            echo ""
+            echo "Sora fal.ai failed — falling back to Kling fal.ai..."
+            if ! generate_kling_fal; then
+                echo ""
+                echo "Kling fal.ai failed — falling back to Kling Replicate..."
+                PROVIDER="replicate"
+                generate_replicate_kling
+            fi
+        fi
+        ;;
+    kling)
+        # Skip Sora entirely — use when Sora is sunset
+        if ! generate_kling_fal; then
+            echo ""
+            echo "Kling fal.ai failed — falling back to Kling Replicate..."
+            PROVIDER="replicate"
+            generate_replicate_kling
+        fi
         ;;
     replicate)
         generate_replicate
         ;;
     *)
-        echo "Error: unknown provider '$PROVIDER' (use 'fal' or 'replicate')" >&2
+        echo "Error: unknown provider '$PROVIDER' (use 'fal', 'kling', or 'replicate')" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

Refactored the video generation system to implement a robust fallback chain: **Sora 2 (fal.ai) → Kling 3 (fal.ai) → Kling 3 (Replicate)**. This ensures A-roll generation continues when Sora becomes unavailable or is sunset, while maintaining backward compatibility with existing workflows.

## Key Changes

- **Fallback chain implementation**: `generate-clip.sh` now automatically falls back from Sora to Kling (fal.ai) to Kling (Replicate) on failure
- **New `--provider kling` option**: Allows skipping Sora entirely for when it's sunset, going directly to Kling fal.ai → Replicate
- **Added `generate_kling_fal()` function**: Implements fal.ai Kling 3 video generation with duration clamping (3-15s) and audio generation for dialogue sync
- **Added `generate_replicate_kling()` function**: Implements Replicate Kling 3 Omni as final fallback with file upload support for local images
- **Shared utilities**: Extracted common aspect ratio mapping and logging logic into reusable functions (`log_entry()`, `MAPPED_ASPECT`)
- **Updated documentation**: 
  - `references/sora-api.md` now documents Kling 3 endpoints, schemas, and timing comparisons
  - `SKILL.md` updated to reflect fallback chain and new `--provider kling` usage
  - Usage examples added for Kling-direct and legacy Replicate Sora paths
- **Batch scripts updated**: `batch-campaign.sh` and `extend-clip.sh` now accept `--provider` parameter and pass it through to `generate-clip.sh`
- **Error handling**: Changed from `exit` to `return` in provider functions to enable fallback logic; improved error messages to identify which provider failed

## Implementation Details

- **Duration handling**: Kling max is 15s (vs Sora's 20s); durations >15s are auto-clamped with warnings
- **Audio generation**: Kling requires `generate_audio: true` for A-roll (dialogue sync), unlike B-roll usage
- **Field name differences**: Properly handles provider-specific field names (`image_url` for Sora, `start_image_url` for Kling, `start_image` for Replicate)
- **Logging**: Unified log entry format across all providers, tracking model name, request/prediction ID, duration, and provider
- **Backward compatibility**: Default behavior (`--provider fal`) maintains existing workflows while adding automatic fallback

https://claude.ai/code/session_01NdF5c96S8NiBw8nMGiN1R6