### PR TITLE
fix: README Sora deprecation notice + brand templates for non-GrowthClaw users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Brand + Audience
 │  2. Creator profile         │  ← persistent AI "creator" with locked identity
 │  3. Format + script         │  ← 6 formats with shot-by-shot enforcement
 │  4. First frame (Nano Banana)│  ← iPhone-realistic, not AI-looking
-│  5. A-roll (Sora 2)        │  ← talking head with synced voice + lip sync
+│  5. A-roll (Sora 2 → Kling 3)│ ← talking head with synced voice + lip sync
 │  6. B-roll (Kling 3)       │  ← fast contextual scenes, env-matched
 │  7. Audio orchestration     │  ← native voice, continuous over B-roll
 │  8. Post-production         │  ← color grade, grain, frame rate
@@ -84,17 +84,26 @@ bash scripts/check-deps.sh
 
 ## Quick start — your first video in 20 minutes
 
-1. **Run the dependency check** to make sure everything's configured
-2. **Tell the skill what brand and who the audience is** — it handles persona research
-3. **Pick a format** — the skill recommends one based on your goal
-4. **Approve the script** — it writes one mapped to the format's shot breakdown
-5. **Generate the first frame** — review it before committing to video
-6. **Generate video + B-roll** — Sora for talking head, Kling for B-roll scenes
-7. **Post-production + captions** — automated color grade, grain, caption overlay
-8. **Virality score** — only publish if it scores 70+
+1. **Set up brand context** — if you have GrowthClaw, it writes `workspace/brand/` for you. If not, copy the templates from `assets/` and fill them in manually:
+   ```bash
+   mkdir -p workspace/brand
+   cp assets/voice-profile-template.md workspace/brand/voice-profile.md
+   cp assets/positioning-template.md workspace/brand/positioning.md
+   cp assets/audience-template.md workspace/brand/audience.md
+   ```
+2. **Run the dependency check** to make sure everything's configured
+3. **Tell the skill what brand and who the audience is** — it handles persona research
+4. **Pick a format** — the skill recommends one based on your goal
+5. **Approve the script** — it writes one mapped to the format's shot breakdown
+6. **Generate the first frame** — review it before committing to video
+7. **Generate video + B-roll** — Sora 2 (or Kling 3 fallback) for talking head, Kling for B-roll scenes
+8. **Post-production + captions** — automated color grade, grain, caption overlay
+9. **Virality score** — only publish if it scores 70+
 
 ## Key findings from testing
 
+- **Sora 2 API is being deprecated.** Kling 3 is the primary fallback and may become the default A-roll provider. The pipeline handles this automatically via `generate-clip.sh`, or use `--provider kling` to skip Sora entirely.
+- **Kling 3 is the go-to for B-roll AND A-roll fallback.** It has no content safety filter, supports 3–15s durations, and produces consistent results for both talking head and environment shots.
 - **Sora's native voice is always better than ElevenLabs TTS** for talking head. TTS sounds fake. Sora does voice + lip sync together.
 - **B-roll must be environment-matched.** Extract a frame from the A-roll → feed to Kling. Generic B-roll looks like stock footage.
 - **Captions go LAST** — after post-production. Grain degrades caption pills.
@@ -134,7 +143,7 @@ scrollclaw/
 │   └── references/
 │       ├── first-frame-prompting.md
 │       └── first-frame-psychology.md
-├── animate/                    Step 3: A-roll (Sora 2)
+├── animate/                    Step 3: A-roll (Sora 2 → Kling 3)
 │   ├── SKILL.md
 │   └── references/
 │       ├── motion-prompting.md
@@ -158,7 +167,7 @@ scrollclaw/
 │       └── virality-scoring.md
 ├── scripts/                    10 automation scripts
 ├── evals/                      Baseline, trigger, and execution benchmarks
-└── assets/                     Campaign brief template
+└── assets/                     Campaign brief + brand templates
 ```
 
 ## Brand & Campaign Context
@@ -167,7 +176,7 @@ ScrollClaw persists work across sessions so campaign 10 takes a fraction of camp
 
 ```
 workspace/
-├── brand/                      ← Read-only for ScrollClaw (GrowthClaw or manual)
+├── brand/                      ← Read-only for ScrollClaw (GrowthClaw or manual — see assets/ for templates)
 │   ├── voice-profile.md        ← Informs script tone
 │   ├── positioning.md          ← Informs persona research direction
 │   └── audience.md             ← Anchors creator archetype selection

--- a/_system/references/brand-campaign-context.md
+++ b/_system/references/brand-campaign-context.md
@@ -14,7 +14,7 @@ Campaign 10 should take a fraction of campaign 1. Creator profiles get reused. L
 
 ```
 workspace/
-├── brand/                          ← Read-only for ScrollClaw. Written by GrowthClaw or manually.
+├── brand/                          ← Read-only for ScrollClaw. Written by GrowthClaw or manually from templates.
 │   ├── voice-profile.md            ← Brand voice, tone, language style
 │   ├── positioning.md              ← What the brand stands for, how it differentiates
 │   └── audience.md                 ← ICP, customer archetypes, demographics
@@ -47,7 +47,14 @@ workspace/
 
 ## Brand Context Integration
 
-ScrollClaw is a good citizen in a larger skill ecosystem. It **reads** from `workspace/brand/` but **never writes** there. Writing brand files is the job of brand-focused skills (GrowthClaw, brand-voice, etc.).
+ScrollClaw is a good citizen in a larger skill ecosystem. It **reads** from `workspace/brand/` but **never writes** there. Writing brand files is the job of brand-focused skills (GrowthClaw, brand-voice, etc.) or the user manually. If you don't have GrowthClaw, copy the templates from `assets/` and fill them in:
+
+```bash
+mkdir -p workspace/brand
+cp assets/voice-profile-template.md workspace/brand/voice-profile.md
+cp assets/positioning-template.md workspace/brand/positioning.md
+cp assets/audience-template.md workspace/brand/audience.md
+```
 
 ### What gets read and how
 

--- a/assets/audience-template.md
+++ b/assets/audience-template.md
@@ -1,0 +1,23 @@
+# Audience Profile
+
+## Ideal Customer
+- **Who:** (specific person — "35-year-old suburban mom with two kids" not "women 25-45")
+- **Where they hang out online:** (TikTok, Instagram Reels, YouTube Shorts, Reddit, etc.)
+- **What they search for:** (actual search terms and questions they type)
+
+## Demographics
+- **Age range:**
+- **Gender split:**
+- **Location:**
+- **Income level:**
+- **Job / life stage:**
+
+## Psychographics
+- **What they value:** (e.g., convenience, authenticity, status, health)
+- **What they're skeptical about:** (e.g., "too good to be true" claims, influencer endorsements)
+- **What makes them stop scrolling:** (e.g., relatable frustration, unexpected results, real talk)
+
+## Creator Archetype Match
+- **The audience trusts someone who looks like:** (e.g., "a peer, not a model — someone who could be their neighbor")
+- **Age range for creator:** (should match or slightly aspirational)
+- **Vibe:** (e.g., put-together but not perfect, visibly tired but upbeat, polished professional)

--- a/assets/positioning-template.md
+++ b/assets/positioning-template.md
@@ -1,0 +1,20 @@
+# Brand Positioning
+
+## What We Are
+- **Category:** (e.g., meal kit delivery, project management SaaS, skincare)
+- **One-line positioning:** (what you do + for whom + why it's different)
+
+## Differentiation
+- **Primary differentiator:** (the ONE thing that separates you)
+- **Supporting differentiators:** (2-3 more reasons you're not just-another-one)
+- **What competitors say that we DON'T:** (claims you avoid)
+
+## Pain Points We Own
+- **Primary pain point:** (the #1 problem your audience has that you solve)
+- **Secondary pain points:** (2-3 more)
+- **Emotional undercurrent:** (what the pain point actually FEELS like — frustration, embarrassment, overwhelm)
+
+## Proof Points
+- **Numbers:** (users, revenue, time saved — anything concrete)
+- **Social proof:** (notable customers, press mentions, awards)
+- **Before/after:** (what life looks like before vs after your product)

--- a/assets/voice-profile-template.md
+++ b/assets/voice-profile-template.md
@@ -1,0 +1,20 @@
+# Brand Voice Profile
+
+## Voice Character
+- **Personality:** (e.g., friendly expert, straight-talking friend, calm authority)
+- **Energy level:** (e.g., high-energy enthusiast, low-key conversational, measured and thoughtful)
+
+## Tone
+- **Default tone:** (e.g., conversational and direct, no corporate speak)
+- **What we sound like:** (3-5 phrases that capture the vibe)
+- **What we DON'T sound like:** (3-5 anti-patterns to avoid)
+
+## Language Style
+- **Sentence structure:** (e.g., short punchy sentences, casual fragments OK)
+- **Vocabulary level:** (e.g., 8th grade reading level, avoid jargon)
+- **Filler words / verbal tics:** (e.g., "honestly," "look," "here's the thing" — these make UGC feel real)
+
+## Script Calibration
+- **Opening style:** (e.g., jump straight into the point, no "hey guys")
+- **CTA style:** (e.g., soft nudge not hard sell, "just try it" not "buy now")
+- **Proof style:** (e.g., personal experience, specific numbers, before/after)

--- a/scripts/pre-flight.sh
+++ b/scripts/pre-flight.sh
@@ -103,7 +103,34 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# 2. Creator profile
+# 2. Brand context (warn-only — not required)
+# ─────────────────────────────────────────────
+
+header "Brand Context"
+
+BRAND_DIR="$REPO_ROOT/workspace/brand"
+BRAND_FILES=("voice-profile.md" "positioning.md" "audience.md")
+BRAND_FOUND=0
+
+for bf in "${BRAND_FILES[@]}"; do
+  if [[ -f "$BRAND_DIR/$bf" ]]; then
+    pass "$bf"
+    BRAND_FOUND=$((BRAND_FOUND + 1))
+  else
+    warn "$bf not found — persona research will infer from campaign brief only"
+  fi
+done
+
+if [[ $BRAND_FOUND -eq 0 ]]; then
+  info "No brand files found. Copy templates to get started:"
+  info "  mkdir -p workspace/brand"
+  info "  cp assets/voice-profile-template.md workspace/brand/voice-profile.md"
+  info "  cp assets/positioning-template.md workspace/brand/positioning.md"
+  info "  cp assets/audience-template.md workspace/brand/audience.md"
+fi
+
+# ─────────────────────────────────────────────
+# 3. Creator profile
 # ─────────────────────────────────────────────
 
 header "Creator Profile"
@@ -133,7 +160,7 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# 3. Reference image for i2v
+# 4. Reference image for i2v
 # ─────────────────────────────────────────────
 
 header "Reference Image"
@@ -163,7 +190,7 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# 4. Script with segment mapping
+# 5. Script with segment mapping
 # ─────────────────────────────────────────────
 
 header "Script"
@@ -197,7 +224,7 @@ else
 fi
 
 # ─────────────────────────────────────────────
-# 5. Caption plan
+# 6. Caption plan
 # ─────────────────────────────────────────────
 
 header "Caption Plan"
@@ -226,7 +253,7 @@ if [[ "$HAS_CAPTION_PLAN" == "false" ]]; then
 fi
 
 # ─────────────────────────────────────────────
-# 6. Text style parameters
+# 7. Text style parameters
 # ─────────────────────────────────────────────
 
 header "Text Style"


### PR DESCRIPTION
## Changes

### README updates
- Pipeline diagram now shows Sora 2 → Kling 3 fallback chain
- Added deprecation notice: Sora API is being sunset, Kling 3 is the fallback (and future default)
- Key findings updated with Kling notes

### Brand templates for standalone use
- Added `assets/voice-profile-template.md` — fill in brand voice in ~5 min
- Added `assets/positioning-template.md` — brand differentiation  
- Added `assets/audience-template.md` — ICP and customer archetypes
- Quick Start updated: 'If you don't have GrowthClaw, copy templates from assets/'

### Pre-flight update
- Now warns (doesn't fail) when workspace/brand/ files are missing

### Note on graceful degradation
The sub-skills (persona, system) already handle missing brand files gracefully — they show what loaded and proceed standalone. No code changes needed there.