### PR TITLE
feat: add /brand-setup — one-time brand initialization for standalone use

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ ScrollClaw persists work across sessions so campaign 10 takes a fraction of camp
 
 ```
 workspace/
-├── brand/                      ← Read-only for ScrollClaw (GrowthClaw or manual — see assets/ for templates)
+├── brand/                      ← Written by /brand-setup (recommended), GrowthClaw, or manually from assets/ templates
 │   ├── voice-profile.md        ← Informs script tone
 │   ├── positioning.md          ← Informs persona research direction
 │   └── audience.md             ← Anchors creator archetype selection

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Not by adding filters after. By building the entire pipeline around anti-polish:
 ## What it produces
 
 ```
+Brand name + URL
+      ↓
+┌─────────────────────────────┐
+│  0. Brand setup (/brand-setup)│ ← one-time: research brand, generate context files
+└─────────────────────────────┘
+      ↓
 Brand + Audience
       ↓
 ┌─────────────────────────────┐
@@ -84,8 +90,10 @@ bash scripts/check-deps.sh
 
 ## Quick start — your first video in 20 minutes
 
-1. **Set up brand context** — if you have GrowthClaw, it writes `workspace/brand/` for you. If not, copy the templates from `assets/` and fill them in manually:
+1. **Set up brand context** — run `/brand-setup` with your brand name and URL. It researches the brand and auto-generates all three files in `workspace/brand/`. Alternatively, if you have GrowthClaw it writes these for you, or copy the templates from `assets/` and fill them in manually:
    ```bash
+   # Option A (recommended): /brand-setup — automatic research + generation
+   # Option B: manual templates
    mkdir -p workspace/brand
    cp assets/voice-profile-template.md workspace/brand/voice-profile.md
    cp assets/positioning-template.md workspace/brand/positioning.md
@@ -133,6 +141,10 @@ scrollclaw/
 │       ├── format-library.md
 │       ├── hook-emotions.md
 │       └── taste-calibration.md
+├── brand-setup/                Step 0: One-time brand research + file generation
+│   ├── SKILL.md
+│   └── references/
+│       └── research-protocol.md
 ├── persona/                    Step 1: Persona research + scripting
 │   ├── SKILL.md
 │   └── references/

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,6 +24,10 @@ AI-generated UGC videos that look like a real person pulled out their phone and 
 ## The Pipeline
 
 ```
+Brand name + URL
+      ↓
+/brand-setup → One-time brand research + file generation (Step 0)
+      ↓
 Brand + Audience
       ↓
 /persona    → Persona research, creator profiles, approved script
@@ -48,6 +52,7 @@ When the user invokes ScrollClaw or asks about UGC video, route to the right sub
 
 | User says / wants | Route to |
 |-------------------|----------|
+| "Set up a brand" / "Initialize brand" / "New brand" / "Brand research" | `/brand-setup` — one-time, before first campaign |
 | "Make me a UGC video" / "Start a campaign" / "I need ugc" | `/persona` — start at the beginning |
 | "Research this brand" / "Create a creator profile" / "Write a script" | `/persona` |
 | "Generate the first frame" / "Make a face image" / "Nano Banana" | `/first-frame` |
@@ -87,7 +92,10 @@ If the user isn't sure where they are, ask: **"Where are you in the pipeline?"**
 ## Quick Start
 
 **First campaign:**
-1. Initialize workspace:
+1. Set up brand context (one-time per brand):
+   - **Recommended:** Run `/brand-setup` with your brand name + URL — it researches and generates all three brand files automatically
+   - **Alternative:** Copy templates from `assets/` and fill in manually (see `assets/` for templates)
+2. Initialize workspace:
    ```bash
    CAMPAIGN="my-campaign"
    mkdir -p workspace/campaigns/$CAMPAIGN/{creators,scripts,frames,clips,scores}
@@ -95,8 +103,8 @@ If the user isn't sure where they are, ask: **"Where are you in the pipeline?"**
    touch workspace/campaigns/$CAMPAIGN/output-log.md
    touch workspace/campaigns/$CAMPAIGN/learnings.md
    ```
-2. Fill in `workspace/campaigns/$CAMPAIGN/brief.md`
-3. Run `/persona` → `/first-frame` → `/animate` → `/b-roll` → `/assemble` → `/score`
+3. Fill in `workspace/campaigns/$CAMPAIGN/brief.md`
+4. Run `/persona` → `/first-frame` → `/animate` → `/b-roll` → `/assemble` → `/score`
 
 **Check setup first:**
 ```bash

--- a/_system/SKILL.md
+++ b/_system/SKILL.md
@@ -49,6 +49,7 @@ Read `references/format-library.md` for shot-by-shot blueprints. Read `reference
 
 | Step | Skill | What happens |
 |------|-------|-------------|
+| 0. Brand setup (one-time) | `/brand-setup` | Research brand, generate voice/positioning/audience files |
 | 1. Persona research | `/persona` | Mine reviews, extract real language |
 | 2. Brand context | `/persona` | Load brand voice, know the product |
 | 3. Creator profiles | `/persona` | Lock identity in `workspace/campaigns/<slug>/creators/` or `workspace/creators/` |
@@ -95,7 +96,7 @@ ScrollClaw persists work across sessions using a structured workspace. Campaign 
 
 ```
 workspace/
-├── brand/                    ← Read-only for ScrollClaw (written by GrowthClaw etc.)
+├── brand/                    ← Read-only for ScrollClaw (written by /brand-setup, GrowthClaw, or manually)
 │   ├── voice-profile.md      ← Brand voice → informs script tone
 │   ├── positioning.md        ← Differentiation → informs persona research
 │   └── audience.md           ← ICP → informs creator archetype selection
@@ -116,6 +117,7 @@ workspace/
 
 | Skill | Reads | Writes |
 |-------|-------|--------|
+| `/brand-setup` | Brand website, social profiles, reviews, competitors (scraped) | `brand/voice-profile.md`, `brand/positioning.md`, `brand/audience.md` |
 | `/persona` | `brand/{voice-profile,positioning,audience}.md`, campaign brief | `persona-research.md`, `creators/`, `scripts/` |
 | `/first-frame` | `creators/`, `scripts/`, campaign brief | `frames/`, `output-log.md` |
 | `/animate` | `frames/`, `scripts/`, `creators/` | `clips/a-roll-*.mp4`, `output-log.md` |

--- a/_system/references/brand-campaign-context.md
+++ b/_system/references/brand-campaign-context.md
@@ -14,7 +14,7 @@ Campaign 10 should take a fraction of campaign 1. Creator profiles get reused. L
 
 ```
 workspace/
-├── brand/                          ← Read-only for ScrollClaw. Written by GrowthClaw or manually from templates.
+├── brand/                          ← Read-only for ScrollClaw. Written by /brand-setup, GrowthClaw, or manually from templates.
 │   ├── voice-profile.md            ← Brand voice, tone, language style
 │   ├── positioning.md              ← What the brand stands for, how it differentiates
 │   └── audience.md                 ← ICP, customer archetypes, demographics
@@ -47,14 +47,25 @@ workspace/
 
 ## Brand Context Integration
 
-ScrollClaw is a good citizen in a larger skill ecosystem. It **reads** from `workspace/brand/` but **never writes** there. Writing brand files is the job of brand-focused skills (GrowthClaw, brand-voice, etc.) or the user manually. If you don't have GrowthClaw, copy the templates from `assets/` and fill them in:
+ScrollClaw is a good citizen in a larger skill ecosystem. It **reads** from `workspace/brand/` but **never writes** there (except `/brand-setup`, which is the one-time writer). There are three ways to populate `workspace/brand/`:
+
+### How to populate brand files (pick one)
+
+| Method | When to use | How |
+|--------|-------------|-----|
+| **`/brand-setup`** (recommended) | New brand, no existing context | Provide brand name + URL. Researches and auto-generates all three files. |
+| **GrowthClaw** | If you have GrowthClaw in your skill ecosystem | GrowthClaw writes brand files as part of its growth strategy workflow. |
+| **Manual templates** (fallback) | Quick start or brands with existing guidelines | Copy templates from `assets/` and fill them in manually. |
 
 ```bash
+# Manual template approach (fallback):
 mkdir -p workspace/brand
 cp assets/voice-profile-template.md workspace/brand/voice-profile.md
 cp assets/positioning-template.md workspace/brand/positioning.md
 cp assets/audience-template.md workspace/brand/audience.md
 ```
+
+`/brand-setup` is the recommended path for most users. It runs once per brand, before any campaign work. The files it generates are read-only after creation — `/brand-setup` writes them, everything else reads them.
 
 ### What gets read and how
 
@@ -87,6 +98,7 @@ Which sub-skills read and write which files.
 
 | Skill | Reads | Writes |
 |-------|-------|--------|
+| `/brand-setup` | Brand website, social profiles, reviews, competitors (scraped) | `workspace/brand/voice-profile.md`<br>`workspace/brand/positioning.md`<br>`workspace/brand/audience.md` |
 | `/persona` | `workspace/brand/voice-profile.md`<br>`workspace/brand/positioning.md`<br>`workspace/brand/audience.md`<br>`campaigns/<slug>/brief.md` | `campaigns/<slug>/persona-research.md`<br>`campaigns/<slug>/creators/creator-<name>.md`<br>`workspace/creators/creator-<name>.md` (global profiles)<br>`campaigns/<slug>/scripts/<format>-script.md` |
 | `/first-frame` | `campaigns/<slug>/creators/creator-<name>.md`<br>`campaigns/<slug>/scripts/<format>-script.md`<br>`campaigns/<slug>/brief.md` | `campaigns/<slug>/frames/frame1.png`<br>`campaigns/<slug>/frames/environment-frame.png`<br>`campaigns/<slug>/output-log.md` |
 | `/animate` | `campaigns/<slug>/frames/frame1.png`<br>`campaigns/<slug>/scripts/<format>-script.md`<br>`campaigns/<slug>/creators/creator-<name>.md` | `campaigns/<slug>/clips/a-roll-*.mp4`<br>`campaigns/<slug>/output-log.md` |

--- a/brand-setup/SKILL.md
+++ b/brand-setup/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: scrollclaw-brand-setup
+description: "One-time brand initialization. Given a brand name and URL, researches the brand and generates the three workspace/brand/ files that the rest of the pipeline reads. Run once per brand before any campaign work."
+metadata:
+  openclaw:
+    emoji: "🏷️"
+    user-invocable: true
+    triggers:
+      - "brand setup"
+      - "set up a brand"
+      - "initialize brand"
+      - "new brand"
+      - "brand research"
+      - "brand init"
+      - "setup brand"
+      - "brand profile"
+---
+
+# Brand Setup
+
+One-time initialization. Run this before your first campaign to populate the three brand files that every other skill reads. After this, you never need GrowthClaw or manual templates.
+
+## What This Does
+
+Given a brand name and website URL, this skill:
+1. Scrapes the brand's website for voice, positioning, and product details
+2. Checks their social presence for how they actually talk to customers
+3. Mines reviews and comments for audience language and pain points
+4. Scans 2-3 competitors for positioning gaps
+5. Generates three files in `workspace/brand/` that the rest of the pipeline consumes
+
+## Step 1: Collect Inputs
+
+**Required:**
+- Brand name
+- Website URL (homepage)
+
+**Optional (improve output quality):**
+- Social media URLs (X/Twitter, Instagram, TikTok, LinkedIn)
+- Competitor names or URLs (2-3)
+- Product category or vertical
+- Any existing brand guidelines or tone docs
+
+If the user only provides brand name + URL, that's enough. Research fills the gaps.
+
+## Step 2: Research the Brand
+
+Read `references/research-protocol.md` for the full protocol. Summary:
+
+### 2a. Website Scrape
+Scrape these pages (in order of priority):
+1. **Homepage** — positioning, hero copy, value props, overall energy
+2. **About / Our Story** — founding narrative, mission language, personality
+3. **Product pages (top 2-3)** — feature language, benefit framing, price positioning
+4. **FAQ or Help** — how they talk when being helpful vs selling
+
+Extract: sentence structure, formality level, jargon, banned words (what they avoid), energy (calm vs urgent), humor presence, emoji use.
+
+### 2b. Social Media Scan
+Check their active social profiles (X/Twitter and Instagram minimum):
+- How do they talk in captions vs replies?
+- Do they use emoji? How much?
+- Formal or casual? First person or third?
+- Do they joke? What kind of humor?
+- What hashtags/language patterns repeat?
+
+Focus on the **gap between website copy and social voice** — social is usually more authentic and closer to how a UGC script should sound.
+
+### 2c. Review Mining
+Find 15-30 customer reviews from:
+- Amazon (if applicable)
+- Reddit (search brand name + product category)
+- Social media comments (Instagram, TikTok, X)
+- Trustpilot / G2 / app store reviews (depending on product type)
+
+Extract:
+- Exact phrases customers use to describe the problem ("I was so tired of...")
+- Exact phrases for the result ("now I actually...")
+- Emotional language — frustration, relief, surprise, delight
+- Demographic signals — life stage, context clues, purchase motivations
+- Objections and hesitations before buying
+
+### 2d. Competitor Scan
+Scan the homepage + positioning of 2-3 competitors:
+- What claims do they all make? (these are table stakes, not differentiators)
+- What does THIS brand say that competitors don't?
+- What positioning gaps exist?
+- What audience segments are underserved?
+
+## Step 3: Generate the Three Files
+
+### `workspace/brand/voice-profile.md`
+
+Must include:
+- **Tone spectrum:** where the brand sits on formal↔casual, serious↔playful, expert↔peer
+- **Energy level:** calm/measured vs urgent/energetic vs somewhere between
+- **Sentence patterns:** short and punchy? Long and flowing? Mixed?
+- **Vocabulary:** words they love, words they never use
+- **What they say vs don't say:** specific phrases the brand uses repeatedly vs language they avoid
+- **Example phrases:** 5-10 real phrases pulled from their content that capture the voice
+- **UGC calibration:** how the voice should shift for UGC context (slightly more casual, more first-person, more "real talk")
+
+### `workspace/brand/positioning.md`
+
+Must include:
+- **One-line positioning:** what they are and for whom, in one sentence
+- **Core value props:** 3-5 key benefits in the brand's language
+- **Differentiation:** what they claim that competitors don't
+- **Competitive landscape:** who they compete with and how they position against each
+- **Price positioning:** premium, mid-market, accessible, or value
+- **Proof points:** stats, awards, testimonials, social proof they lean on
+- **UGC angles:** 2-3 angles that would work for UGC scripting based on their positioning
+
+### `workspace/brand/audience.md`
+
+Must include:
+- **Primary ICP:** demographics + psychographics in plain language
+- **Life stage and context:** when/why do they buy this? What's happening in their life?
+- **Pain points (in customer language):** exact phrases from reviews, not marketing-speak
+- **Purchase motivations:** what pushes them from considering to buying?
+- **Objections:** what almost stopped them from buying?
+- **Language patterns:** how this audience talks about this problem category
+- **Creator archetype match:** what kind of UGC creator would this audience trust? (age range, vibe, aesthetic, energy)
+- **Anti-patterns:** creator types that would NOT work for this audience
+
+## Step 4: Validate
+
+After generating the three files:
+
+1. **Existence check:** all three files exist in `workspace/brand/`
+2. **Substance check:** each file has real, specific content — not just headers with generic filler
+3. **Specificity test:** could a script writer use these files without ever visiting the brand's website? If not, the files need more detail
+4. **Pre-flight check:** run `bash scripts/pre-flight.sh` brand checks — the brand section should pass
+
+Show the user a summary:
+
+```
+🏷️ Brand setup complete: <brand name>
+
+  ✓ workspace/brand/voice-profile.md — <tone summary, e.g. "conversational-direct, no corporate speak">
+  ✓ workspace/brand/positioning.md — <one-line positioning>
+  ✓ workspace/brand/audience.md — <primary ICP summary>
+
+Files are ready. Run /persona to start your first campaign.
+```
+
+## Step 5: Handle Existing Files
+
+If `workspace/brand/` already has files:
+- Show what exists and when it was last modified
+- Ask the user: **"Brand files already exist. Overwrite, merge, or skip?"**
+  - **Overwrite:** replace all three files with fresh research
+  - **Merge:** keep existing content, add new findings, flag conflicts
+  - **Skip:** abort brand setup, use existing files
+
+Never silently overwrite existing brand files.
+
+## Brand Memory Integration
+
+### Reads
+| File | Purpose |
+|------|---------|
+| Brand's website (scraped) | Voice, positioning, product details |
+| Brand's social profiles (scraped) | Authentic voice patterns, engagement style |
+| Customer reviews (scraped) | Audience language, pain points, demographics |
+| Competitor homepages (scraped) | Positioning gaps, differentiation |
+
+### Writes
+| File | Notes |
+|------|-------|
+| `workspace/brand/voice-profile.md` | Brand voice, tone, vocabulary, example phrases. Read by `/persona` for script calibration. |
+| `workspace/brand/positioning.md` | Differentiation, value props, competitive landscape. Read by `/persona` for pain point emphasis. |
+| `workspace/brand/audience.md` | ICP, customer language, creator archetype guidance. Read by `/persona` for creator selection. |
+
+### Context loading (show this to the user at session start)
+
+```
+🏷️ Brand Setup for: <brand name>
+  Input: <brand URL>
+  Social: <social URLs if provided, or "will discover">
+  Competitors: <competitor names if provided, or "will identify from research">
+  Existing brand files: <none / list what exists>
+```
+
+## Contract
+
+### Input
+- Required: brand name + website URL
+- Optional: social media URLs, competitor names/URLs, product category, existing brand guidelines
+- Format: plain text (brand name, URLs) provided by user
+- Source: user prompt
+
+### Output
+- Produces: three brand context files in `workspace/brand/`
+- Format: structured markdown files following the schemas defined in Step 3
+- Default behavior: research the brand, generate all three files, validate, and present summary
+- Downstream use: `/persona` (reads all three files), and indirectly every other pipeline skill
+
+### Validation
+- Pre-conditions: brand name and URL are provided; workspace/ directory exists (create if not)
+- Post-conditions: all three files exist in `workspace/brand/` with substantive content; pre-flight brand checks pass
+- Failure checks: if scraping fails for a source, note it and proceed with available data; never generate files with only headers and no content; if research yields insufficient data, tell the user what's missing and ask for additional input
+
+## Next Step
+
+Brand files populated → run `/persona` to start your first campaign.

--- a/brand-setup/references/research-protocol.md
+++ b/brand-setup/references/research-protocol.md
@@ -1,0 +1,209 @@
+# Brand Research Protocol
+
+How to research a brand well enough that a script writer never needs to visit the brand's website. Every section below is a specific extraction target — not a vague "look at the brand."
+
+---
+
+## Website Scraping
+
+### Homepage (always first)
+
+**What to extract:**
+- Hero headline and subheadline — this is how they want to be perceived
+- Value proposition structure — do they lead with benefits, features, or emotion?
+- Social proof placement — reviews, logos, stats? What do they choose to prove?
+- CTA language — "Get started" vs "Try free" vs "Shop now" reveals formality and urgency
+- Visual energy — minimal and calm, or bold and loud?
+
+**What to note:**
+- Words that repeat across sections (these are core vocabulary)
+- Words conspicuously absent (these are avoided on purpose)
+- Whether they address the reader as "you" or talk about "our customers"
+
+### About / Our Story
+
+**What to extract:**
+- Founding narrative — what problem motivated creating the brand?
+- Mission language — aspirational or practical?
+- Team presentation — do they show founders? Use first names? Professional headshots or casual?
+- Brand personality leaks — humor, directness, warmth, edge?
+
+**Why this matters:** The about page is where brands drop the sales posture. The language here is closer to the founder's actual voice, which is closer to what UGC should sound like.
+
+### Product Pages (top 2-3 by prominence)
+
+**What to extract:**
+- How they describe features — technical specs or benefit-first?
+- Price framing — do they anchor against alternatives? Use "starting at" language? Show per-unit savings?
+- Review highlights — which reviews do they choose to feature? This reveals what they want customers to feel.
+- Comparison language — do they explicitly compare to competitors or stay in their own lane?
+
+### FAQ / Help / Support
+
+**What to extract:**
+- Tone shift — are they warmer here? More direct? More casual?
+- Common objections surfaced — what questions do they anticipate?
+- The "helpful voice" — this is often the most natural version of the brand's voice
+
+---
+
+## Social Media Voice Extraction
+
+### What to scan
+
+Check the two most active profiles. Priority order: X/Twitter → Instagram → TikTok → LinkedIn.
+
+For each platform, look at:
+- **Last 20-30 posts** (captions, not just images)
+- **5-10 replies** to customers or commenters
+- **Bio and pinned content** — this is their self-description at its most compressed
+
+### What to extract
+
+| Pattern | How to identify | Why it matters |
+|---------|----------------|---------------|
+| Formality level | "We're excited to announce" vs "ok this one's good" | Sets the UGC tone ceiling |
+| Emoji density | None / light / heavy / every sentence | UGC should match or slightly exceed |
+| Sentence length | Short punchy vs flowing narrative | Script pacing mirror |
+| Humor type | None / dry / self-deprecating / hype | Scripts need to match this exactly |
+| Engagement style | Professional / friendly / playful / edgy | Creator persona calibration |
+| First vs third person | "We made" vs "Brand X introduces" | UGC is always first person but vocabulary carries |
+| Hashtag behavior | None / branded / trending / category | Skip for UGC but reveals how they think about reach |
+
+### The Website-Social Gap
+
+The most valuable signal is the **difference** between website copy and social voice. Brands are typically more formal on-site and more casual on social. UGC should sit slightly past the social end of this spectrum — a bit more casual than their most casual social post.
+
+Document this gap explicitly:
+```
+Website tone: professional, benefit-driven, measured
+Social tone: casual, emoji-light, direct, occasionally funny
+UGC calibration: conversational, first-person, direct, humor welcome
+```
+
+---
+
+## Review Mining
+
+### Where to look (by product type)
+
+| Product type | Primary sources | Secondary sources |
+|-------------|----------------|-------------------|
+| Physical product (DTC) | Amazon, brand site reviews | Reddit, TikTok comments |
+| SaaS / App | G2, Capterra, App Store/Play Store | Reddit, Twitter, Product Hunt |
+| Service | Trustpilot, Google Reviews | Reddit, industry forums |
+| CPG / Food / Beauty | Amazon, Sephora/Ulta, brand site | TikTok, Instagram comments, Reddit |
+| B2B | G2, Capterra, case study comments | LinkedIn comments, Reddit |
+
+### What to extract
+
+**Problem language (most valuable):**
+- How customers describe the problem BEFORE finding this product
+- Exact emotional words: "frustrated," "embarrassed," "fed up," "desperate"
+- Situational context: when/where the problem hits hardest
+- Previous failed solutions: "I tried X and Y but..."
+
+**Result language:**
+- How customers describe life AFTER the product
+- Specific outcomes, not vague praise: "I slept through the night for the first time in months"
+- Emotional payoff: relief, confidence, surprise, pride
+- Social proof moments: "my friend asked what changed"
+
+**Demographic signals:**
+- Life stage mentions: "as a new mom," "in my 40s," "just started college"
+- Context clues: income signals, location, lifestyle markers
+- Purchase motivation: what specific event or moment triggered buying
+
+**Objections and hesitations:**
+- "I was skeptical because..."
+- "The price seemed high but..."
+- "I almost didn't buy because..."
+- Price sensitivity signals
+- Trust barriers
+
+### Quality over quantity
+
+You need 15-30 reviews, not 200. Prioritize:
+1. Detailed reviews (3+ sentences) over star-only ratings
+2. Reviews that tell a story over reviews that list features
+3. Negative-then-positive reviews ("I was skeptical but...") — these are script gold
+4. Reviews with specific before/after language
+
+### Capture format
+
+Store extracted phrases exactly as written. Do not paraphrase. Do not clean up grammar. The raw language IS the asset.
+
+```
+PROBLEM PHRASES:
+- "I was doing everything right and my body wasn't cooperating"
+- "spent hundreds on products that just sat in my cabinet"
+- "too embarrassed to wear shorts anymore"
+
+RESULT PHRASES:
+- "wore a dress I hadn't put on since my daughter was born"
+- "my husband noticed before I even said anything"
+- "I actually look forward to getting ready now"
+
+OBJECTION PHRASES:
+- "seemed like just another supplement"
+- "the before/afters looked too good"
+- "I don't usually spend this much on skincare"
+```
+
+---
+
+## Competitor Scanning
+
+### Who to scan
+
+If the user provides competitor names, use those. Otherwise, identify 2-3 from:
+- Brands mentioned in customer reviews ("I switched from X")
+- Google search for the product category — who shows up in ads and organic?
+- "Alternatives to [brand]" search results
+
+### What to extract (homepage only — keep this fast)
+
+| Element | What to note |
+|---------|-------------|
+| Hero claim | What's their main promise? |
+| Audience language | Who are they talking to? Same audience or different? |
+| Differentiator | What do they claim that's unique? |
+| Price position | Higher, lower, same tier? |
+| Tone | More corporate? More edgy? More clinical? |
+
+### What to derive
+
+**Table stakes:** Claims ALL competitors make. These are expected, not differentiating. Don't build UGC around these.
+
+**Unique angles:** What THIS brand says that NO competitor says. These are the UGC hooks.
+
+**Positioning gaps:** Audience segments or pain points that no one is addressing well. These are opportunities.
+
+**Tone differentiation:** If every competitor sounds clinical, a conversational UGC voice stands out. If every competitor sounds hype-y, a calm honest-review voice wins.
+
+---
+
+## Output Quality Bar
+
+Each generated file must pass this test:
+
+### Voice Profile Quality Check
+- [ ] Includes specific words the brand uses (not generic descriptors)
+- [ ] Includes specific words the brand avoids
+- [ ] Has 5+ real example phrases pulled from brand content
+- [ ] Identifies the website-social tone gap
+- [ ] Provides a UGC calibration that's actionable (not "be authentic")
+
+### Positioning Quality Check
+- [ ] One-line positioning is specific enough to differentiate from competitors
+- [ ] Value props use the brand's language, not generic benefit statements
+- [ ] Competitive landscape names real competitors with real differences
+- [ ] UGC angles are specific enough to write a script from
+
+### Audience Quality Check
+- [ ] ICP includes demographic AND psychographic detail
+- [ ] Pain points use exact customer language (from reviews)
+- [ ] Creator archetype recommendation is specific (age range, vibe, energy — not "relatable person")
+- [ ] Anti-patterns list creator types that would fail with this audience
+
+If any file fails its quality check, go back to research. More scraping > generic filler.

--- a/scripts/pre-flight.sh
+++ b/scripts/pre-flight.sh
@@ -122,7 +122,8 @@ for bf in "${BRAND_FILES[@]}"; do
 done
 
 if [[ $BRAND_FOUND -eq 0 ]]; then
-  info "No brand files found. Copy templates to get started:"
+  info "No brand files found. Run /brand-setup with your brand name + URL (recommended),"
+  info "or copy templates manually:"
   info "  mkdir -p workspace/brand"
   info "  cp assets/voice-profile-template.md workspace/brand/voice-profile.md"
   info "  cp assets/positioning-template.md workspace/brand/positioning.md"


### PR DESCRIPTION
## What this does

Makes ScrollClaw fully standalone. No GrowthClaw required.

### New: `/brand-setup` sub-skill (Step 0)
Give it a brand name + URL. It researches the brand and generates:
- `workspace/brand/voice-profile.md` — tone, vocabulary, energy, example phrases
- `workspace/brand/positioning.md` — differentiation, value props, competitive landscape  
- `workspace/brand/audience.md` — ICP, pain points, review language, purchase motivations

Runs once per brand. Everything downstream reads these files.

### Research protocol
- Homepage + about page → positioning and voice
- Social media (X, Instagram) → how they actually talk to customers
- Reviews (Amazon, Reddit, social) → audience language in their own words
- Competitor scan (2-3 competitors) → positioning gaps and angles

### Pipeline is now:
```
/brand-setup → /persona → /first-frame → /animate → /b-roll → /assemble → /score
```

### Files
- `brand-setup/SKILL.md` — full skill definition with contract
- `brand-setup/references/research-protocol.md` — research methodology
- Updated: root `SKILL.md` routing table, `README.md` pipeline diagram, `brand-campaign-context.md`

### Review fix
- Added brand-setup to README workspace diagram and pre-flight hints